### PR TITLE
Use public clear function instead of reset

### DIFF
--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -4,7 +4,7 @@ const lru = require('tiny-lru')
 
 function LocalStore (timeWindow, cache) {
   this.lru = lru(cache || 5000)
-  setInterval(this.lru.reset.bind(this.lru), timeWindow).unref()
+  setInterval(this.lru.clear.bind(this.lru), timeWindow).unref()
 }
 
 LocalStore.prototype.incr = function (ip, cb) {


### PR DESCRIPTION
Fixes #13 (now reverted), #15 

see: https://github.com/avoidwork/tiny-lru/commit/d0cdcfefdc740bf2ec5c544de8d7971e0ab4cb31