### PR TITLE
feat: support rate limit for diff route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ typings/
 
 # lockfile
 package-lock.json
+
+dump.rdb

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/fastify/fastify-rate-limit#readme",
   "devDependencies": {
     "fastify": "next",
-    "ioredis": "^4.2.0",
+    "ioredis": "^4.3.0",
     "standard": "^12.0.1",
-    "tap": "^12.1.0"
+    "tap": "^12.1.1"
   },
   "dependencies": {
     "fast-json-stringify": "^1.9.2",
     "fastify-plugin": "^1.3.0",
     "ms": "^2.1.1",
-    "tiny-lru": "^5.0.1"
+    "tiny-lru": "^5.0.3"
   }
 }

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -2,14 +2,22 @@
 
 const lru = require('tiny-lru')
 
-function LocalStore (timeWindow, cache) {
-  this.lru = lru(cache || 5000)
-  setInterval(this.lru.clear.bind(this.lru), timeWindow).unref()
+function LocalStore (opts) {
+  this.lru = lru(opts || 5000)
+  this.timers = {}
 }
 
-LocalStore.prototype.incr = function (ip, cb) {
-  var current = this.lru.get(ip) || 0
-  this.lru.set(ip, ++current)
+LocalStore.prototype.incr = function (key, timeWindow, cb) {
+  let current = this.lru.get(key) || 0
+  this.lru.set(key, ++current)
+
+  if (!this.timers[key]) {
+    this.timers[key] = setTimeout(() => {
+      this.lru.remove(key)
+      this.timers[key] = null
+    }, timeWindow)
+  }
+
   cb(null, current)
 }
 

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -2,22 +2,21 @@
 
 const noop = () => {}
 
-function RedisStore (redis, timeWindow) {
+function RedisStore (redis) {
   this.redis = redis
-  this.timeWindow = timeWindow
-  this.key = 'fastify-rate-limit-'
+  this.prefix = 'fastify-rate-limit-'
 }
 
-RedisStore.prototype.incr = function (ip, cb) {
-  var key = this.key + ip
+RedisStore.prototype.incr = function (key, timeWindow, cb) {
+  const target = this.prefix + key
   this.redis.pipeline()
-    .incr(key)
-    .pttl(key)
+    .incr(target)
+    .pttl(target)
     .exec((err, result) => {
       if (err) return cb(err, 0)
       if (result[0][0]) return cb(result[0][0], 0)
       if (result[1][1] === -1) {
-        this.redis.pexpire(key, this.timeWindow, noop)
+        this.redis.pexpire(target, timeWindow, noop)
       }
       cb(null, result[0][1])
     })

--- a/test.js
+++ b/test.js
@@ -291,3 +291,91 @@ test('With keyGenerator', t => {
     })
   }
 })
+
+test('With special list and global max', t => {
+  t.plan(19)
+
+  const fastify = Fastify()
+  const SPECIAL_URL = '/special-rate'
+
+  fastify.register(rateLimit, {
+    max: 2,
+    timeWindow: 1000,
+    special: [{
+      url: SPECIAL_URL,
+      max: 1,
+      timeWindow: 2000
+    }]
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send('hello!')
+  })
+  fastify.get(SPECIAL_URL, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+    t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+  })
+
+  fastify.inject(SPECIAL_URL, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['x-ratelimit-limit'], 1)
+    t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+
+    fastify.inject(SPECIAL_URL, (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 429)
+      t.strictEqual(res.headers['content-type'], 'application/json')
+      t.strictEqual(res.headers['x-ratelimit-limit'], 1)
+      t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+      t.strictEqual(res.headers['retry-after'], 2000)
+      t.deepEqual({
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded, retry in 2 seconds'
+      }, JSON.parse(res.payload))
+
+      setTimeout(() => {
+        fastify.inject(SPECIAL_URL, (err, res) => {
+          t.error(err)
+          t.strictEqual(res.statusCode, 200)
+          t.strictEqual(res.headers['x-ratelimit-limit'], 1)
+          t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+        })
+      }, 2100)
+    })
+  })
+})
+
+test('With special list and no global max', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+
+  fastify.register(rateLimit, {
+    special: [{
+      url: '/special-rate',
+      max: 1
+    }]
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.send('hello!')
+  })
+  fastify.get('/special-rate', (req, reply) => {
+    reply.send('hello!')
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['x-ratelimit-limit'], undefined)
+    t.strictEqual(res.headers['x-ratelimit-remaining'], undefined)
+  })
+})


### PR DESCRIPTION
This PR is for https://github.com/fastify/fastify-rate-limit/issues/10
It's not all like what @cemremengu said in issue, but come from that.

The rate limit strategy is:

- limit key is consist with `ip` and `url` not just `ip`
- could specify global limit and time window which will affect all urls as default
- could disable the global limit
- could specify limit and time window for some special urls which will overwrite global setting

This PR is not complete yet. I don't know if you like this. So i send this early PR right now and i feel free for any ideas.