### PR TITLE
 change to be able to set by route

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fp = require('fastify-plugin');
 const FJS = require('fast-json-stringify');
 const ms = require('ms');
 
@@ -69,7 +68,7 @@ function rateLimitPlugin (opts) {
     }
   }
 
-  return fp(rateLimit)
+  return rateLimit
 }
 
 module.exports = rateLimitPlugin;


### PR DESCRIPTION
Hello, 

I needed to have the rate-limit by route, instead of globally. 

I did a "major" change (I guess) compare to  ( [the other PR](https://github.com/fastify/fastify-rate-limit/pull/22) ), as it's not anymore a `fastify plugin` but a `middleware` with `fastify.use.(..)` like the following : 

`fastify.use('/path_target', rateLimitObj)`. 

I did not have to change much code to make it works and it seems easier to me to use it as a middleware than adding a `hook` for each `path` like it was originally and it's possible to have different rates by path. 

A simple example  :

```
const fastify = require('fastify')()
const rateLimit = require('fastify-rate-limit');
const limit = rateLimit({
  max: 100,
  timeWindow: '1 minute'
});
fastify.use('/', limit)

fastify.get('/', (req, reply) => {
  reply.send({ hello: 'world' })
})

fastify.listen(3000, err => {
  if (err) throw err
  console.log('Server listening at http://localhost:3000')
})
```

There is probably a way to turn it as a real fastify plugin. 

Thanks


 
