### PR TITLE
fix: package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-rate-limit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A low overhead rate limiter for your routes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
the package.json is not update.

the v2.3.0 is [published in npm](https://www.npmjs.com/package/fastify-rate-limit/v/2.3.0) already
the [release in GH is ok](https://github.com/fastify/fastify-rate-limit/releases/tag/v2.3.0)

so I think a `git push` (from releasify) has failed