### PR TITLE
Fix time window undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,10 @@ function rateLimitPlugin (fastify, settings, next) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const current = Object.create(pluginComponent)
         const mergedRateLimitParams = makeParams(routeOptions.config.rateLimit)
-        routeOptions.config.rateLimit = mergedRateLimitParams
+        if (!routeOptions.config.rateLimit.timeWindow) {
+          // load the global timewindow if it is missing from the route config
+          routeOptions.config.rateLimit.timeWindow = mergedRateLimitParams.timeWindow
+        }
         current.store = pluginComponent.store.child(routeOptions)
         // if the current endpoint have a custom rateLimit configuration ...
         buildRouteRate(current, mergedRateLimitParams, routeOptions)

--- a/index.js
+++ b/index.js
@@ -66,9 +66,11 @@ function rateLimitPlugin (fastify, settings, next) {
     if (routeOptions.config && typeof routeOptions.config.rateLimit !== 'undefined') {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const current = Object.create(pluginComponent)
+        const mergedRateLimitParams = makeParams(routeOptions.config.rateLimit)
+        routeOptions.config.rateLimit = mergedRateLimitParams
         current.store = pluginComponent.store.child(routeOptions)
         // if the current endpoint have a custom rateLimit configuration ...
-        buildRouteRate(current, makeParams(routeOptions.config.rateLimit), routeOptions)
+        buildRouteRate(current, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit === false) {
         // don't apply any rate-limit
       } else {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const lru = require('tiny-lru')
-const ms = require('ms')
 
 function LocalStore (timeWindow, cache, app) {
   this.lru = lru(cache || 5000)
@@ -32,12 +31,8 @@ LocalStore.prototype.incr = function (ip, cb) {
 }
 
 LocalStore.prototype.child = function (routeOptions) {
-  let timeWindow = routeOptions.config.rateLimit.timeWindow
-  if (typeof timeWindow === 'string') {
-    timeWindow = ms(timeWindow)
-  }
-
-  return new LocalStore(timeWindow, routeOptions.config.rateLimit.cache, this.app)
+  return new LocalStore(routeOptions.config.rateLimit.timeWindow,
+    routeOptions.config.rateLimit.cache, this.app)
 }
 
 module.exports = LocalStore

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const ms = require('ms')
 const noop = () => {}
 
 function RedisStore (redis, key, timeWindow) {
@@ -30,13 +29,9 @@ RedisStore.prototype.incr = function (ip, cb) {
 }
 
 RedisStore.prototype.child = function (routeOptions) {
-  let timeWindow = routeOptions.config.rateLimit.timeWindow
-  if (typeof timeWindow === 'string') {
-    timeWindow = ms(timeWindow)
-  }
   const child = Object.create(this)
   child.key = this.key + routeOptions.method + routeOptions.url + '-'
-  child.timeWindow = timeWindow
+  child.timeWindow = routeOptions.config.rateLimit.timeWindow
   return child
 }
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -658,3 +658,53 @@ test('limit reset per Local storage', t => {
     })
   }
 })
+
+test('global timeWindow when not set in routes', t => {
+  t.plan(15)
+  const fastify = Fastify()
+  fastify.register(rateLimit, {
+    global: false,
+    errorResponseBuilder: function (req, context) {
+      return { code: 429, timeWindow: context.after, limit: context.max }
+    }
+  })
+
+  fastify.get('/', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1000
+      }
+    }
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+    t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+
+    fastify.inject('/', (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 200)
+      t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+      t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+
+      fastify.inject('/', (err, res) => {
+        t.error(err)
+        t.strictEqual(res.statusCode, 429)
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+        t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+        t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+        t.strictEqual(res.headers['retry-after'], 1000)
+        t.deepEqual(JSON.parse(res.payload), {
+          code: 429,
+          timeWindow: '1 second',
+          limit: 2
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adding #61 I found this bug that will create a `setInterval` with a time of `undefined` if the user doesn't set the `timeWindow` param in route's configuration.

The current 2.4.0 version is affected