### PR TITLE
Typescript types fix for http2/https

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,31 +1,42 @@
-import * as http from 'http';
+/// <reference types="node" />
 import * as fastify from 'fastify';
+import * as https from "https";
+import { Server, IncomingMessage, ServerResponse } from "http";
+import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
 
-declare namespace fastifyRateLimit {
-  interface FastifyRateLimitOptions {
+type HttpServer = Server | Http2Server | Http2SecureServer | https.Server;
+type HttpRequest = IncomingMessage | Http2ServerRequest;
+type HttpResponse = ServerResponse | Http2ServerResponse;
+
+declare module "fastify" {
+  interface FastifyReply<HttpResponse> {}
+}
+
+declare function fastifyRateLimit(): fastify.Plugin<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  {
     global?: boolean;
-    max?: number | ((req: fastify.FastifyRequest<http.IncomingMessage>, key: string) => number);
+    max?: number | ((req: fastify.FastifyRequest<IncomingMessage>, key: string) => number);
     timeWindow?: number;
     cache?: number;
-    whitelist?: string[] | ((req: fastify.FastifyRequest<http.IncomingMessage>, key: string) => boolean);
+    whitelist?: string[] | ((req: fastify.FastifyRequest<IncomingMessage>, key: string) => boolean);
     redis?: any;
     skipOnError?: boolean;
     ban?: number;
-    keyGenerator?: (req: fastify.FastifyRequest<http.IncomingMessage>) => string | number;
-    errorResponseBuilder?: (req: fastify.FastifyRequest<http.IncomingMessage>, context: errorResponseBuilderContext) => object;
+    keyGenerator?: (req: fastify.FastifyRequest<IncomingMessage>) => string | number;
+    errorResponseBuilder?: (req: fastify.FastifyRequest<IncomingMessage>, context: fastifyRateLimit.errorResponseBuilderContext) => object;
   }
+>;
+
+declare namespace fastifyRateLimit {
+  interface FastifyRateLimitOptions {}
 
   interface errorResponseBuilderContext {
     after: string;
     max: number;
   }
 }
-
-declare let fastifyRateLimit: fastify.Plugin<
-  http.Server,
-  http.IncomingMessage,
-  http.ServerResponse,
-  fastifyRateLimit.FastifyRateLimitOptions
->;
 
 export = fastifyRateLimit;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare function fastifyRateLimit(): fastify.Plugin<
     max?: number | ((req: fastify.FastifyRequest<IncomingMessage>, key: string) => number);
     timeWindow?: number;
     cache?: number;
+    store?: fastifyRateLimit.FastifyRateLimitStoreCtor;
     whitelist?: string[] | ((req: fastify.FastifyRequest<IncomingMessage>, key: string) => boolean);
     redis?: any;
     skipOnError?: boolean;
@@ -36,6 +37,15 @@ declare namespace fastifyRateLimit {
   interface errorResponseBuilderContext {
     after: string;
     max: number;
+  }
+
+  interface FastifyRateLimitStoreCtor {
+    new (options: FastifyRateLimitOptions): FastifyRateLimitStore;
+  }
+
+  interface FastifyRateLimitStore {
+    incr(key: string, callback: ( error: Error|null, result?: { current: number, ttl: number } ) => void): void;
+    child(routeOptions: fastify.RouteOptions<Server, IncomingMessage, ServerResponse> & { path: string, prefix: string }): FastifyRateLimitStore;
   }
 }
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -13,9 +13,8 @@ app.register(fastifyRateLimit, {
   whitelist: ['127.0.0.1'],
   redis: new ioredis({ host: '127.0.0.1' }),
   skipOnError: true,
-  ban: 10,
   keyGenerator: (req: fastify.FastifyRequest<http.IncomingMessage>) => req.ip,
-  errorResponseBuilder: (req: fastify.FastifyRequest<http.IncomingMessage>, context) => ({ code: 429, timeWindow: context.after, limit: context.max })
+  errorResponseBuilder: (req: fastify.FastifyRequest<http.IncomingMessage>, context: fastifyRateLimit.errorResponseBuilderContext) => ({ code: 429, timeWindow: context.after, limit: context.max })
 });
 
 app.register(fastifyRateLimit, {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,11 +1,11 @@
 import * as http from 'http'
+import * as http2 from 'http2'
 import * as fastify from 'fastify';
 import * as fastifyRateLimit from '../../../fastify-rate-limit';
 import * as ioredis from 'ioredis';
 
-const app = fastify();
-
-app.register(fastifyRateLimit, {
+const appWithImplicitHttp = fastify()
+const options1 = {
   global: true,
   max: 3,
   timeWindow: 5000,
@@ -16,11 +16,23 @@ app.register(fastifyRateLimit, {
   ban: 10,
   keyGenerator: (req: fastify.FastifyRequest<http.IncomingMessage>) => req.ip,
   errorResponseBuilder: (req: fastify.FastifyRequest<http.IncomingMessage>, context: fastifyRateLimit.errorResponseBuilderContext) => ({ code: 429, timeWindow: context.after, limit: context.max })
-});
+}
 
-app.register(fastifyRateLimit, {
+const options2 = {
   global: true,
   max: (req: fastify.FastifyRequest<http.IncomingMessage>, key: string) => (42),
   whitelist: (req: fastify.FastifyRequest<http.IncomingMessage>, key: string) => (false),
   timeWindow: 5000
-});
+}
+
+appWithImplicitHttp.register(fastifyRateLimit, options1)
+appWithImplicitHttp.register(fastifyRateLimit, options2)
+
+const appWithHttp2: fastify.FastifyInstance<
+  http2.Http2Server,
+  http2.Http2ServerRequest,
+  http2.Http2ServerResponse
+> = fastify({ http2: true })
+
+appWithHttp2.register(fastifyRateLimit, options1)
+appWithHttp2.register(fastifyRateLimit, options2)

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -13,6 +13,7 @@ app.register(fastifyRateLimit, {
   whitelist: ['127.0.0.1'],
   redis: new ioredis({ host: '127.0.0.1' }),
   skipOnError: true,
+  ban: 10,
   keyGenerator: (req: fastify.FastifyRequest<http.IncomingMessage>) => req.ip,
   errorResponseBuilder: (req: fastify.FastifyRequest<http.IncomingMessage>, context: fastifyRateLimit.errorResponseBuilderContext) => ({ code: 429, timeWindow: context.after, limit: context.max })
 });


### PR DESCRIPTION
Typescript types fix for http2/https for servers like this:

```
const https: fastify.FastifyInstance<Http2SecureServer, Http2ServerRequest, Http2ServerResponse> = fastify({
  logger: log,
  ignoreTrailingSlash: true,
  http2: true,
  https: { allowHTTP1: true }
})
```

One test is failing on my PC even for standart library, but i think it's problem with my PC:
```
test/route-rate-limit.test.js ..................... 218/219
  limit reset per Local storage
  not ok should be equal
    --- wanted
    +++ found
    -2
    +1
    compare: ===
    at:
      line: 686
      column: 9
      file: test/route-rate-limit.test.js
    stack: |
      test/route-rate-limit.test.js:686:9
      node_modules/light-my-request/lib/response.js:26:28
    source: |
      t.strictEqual(res.headers['x-ratelimit-reset'], resetValue)

total ............................................. 380/381


  380 passing (19s)
  1 failing
```

#### Checklist

- [v] run `npm run test` check needed, failing on my PC even for standart library
- [v] tests and/or benchmarks are included
- [-] documentation is changed or added
- [v] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
