### PR TITLE
move to onRequest hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function rateLimitPlugin (fastify, settings, next) {
     globalParams.isCustomErrorMessage = true
   }
 
-  // onRoute add the preHandler rate-limit function if needed
+  // onRoute add the onRequest rate-limit function if needed
   fastify.addHook('onRoute', (routeOptions) => {
     if (routeOptions.config && typeof routeOptions.config.rateLimit !== 'undefined') {
       if (typeof routeOptions.config.rateLimit === 'object') {
@@ -111,16 +111,16 @@ function rateLimitPlugin (fastify, settings, next) {
 function buildRouteRate (pluginComponent, params, routeOptions) {
   const after = ms(params.timeWindow, { long: true })
 
-  if (Array.isArray(routeOptions.preHandler)) {
-    routeOptions.preHandler.push(preHandler)
-  } else if (typeof routeOptions.preHandler === 'function') {
-    routeOptions.preHandler = [routeOptions.preHandler, preHandler]
+  if (Array.isArray(routeOptions.onRequest)) {
+    routeOptions.onRequest.push(onRequest)
+  } else if (typeof routeOptions.onRequest === 'function') {
+    routeOptions.onRequest = [routeOptions.onRequest, onRequest]
   } else {
-    routeOptions.preHandler = [preHandler]
+    routeOptions.onRequest = [onRequest]
   }
 
-  // PreHandler function that will be use for current endpoint been processed
-  function preHandler (req, res, next) {
+  // onRequest function that will be use for current endpoint been processed
+  function onRequest (req, res, next) {
     // We retrieve the key from the generator. (can be the global one, or the one define in the endpoint)
     const key = params.keyGenerator(req)
 


### PR DESCRIPTION
Move to the onRequest hook earlier in the lifecycle and adds tests to confirm nothing further is called int he lifecycle when rate limit is exceeded. 

Fixes #83 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
