### PR TITLE
fix: timeWindow type can be number or string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ interface AddHeaders {
 export interface RateLimitPluginOptions {
   global?: boolean;
   max?: number | ((req: FastifyRequest, key: string) => number);
-  timeWindow?: number;
+  timeWindow?: number | string;
   cache?: number;
   store?: FastifyRateLimitStoreCtor;
   whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This is a very simple fix. `timeWindow` accepts a `string` or `number` (see https://github.com/fastify/fastify-rate-limit/blob/master/index.js#L39), but, in the typescript declaration, only accepts `number`. This PR adds `string` type in the declaration file

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
