### PR TITLE
Feature/fastify-rate-limit add semver range to the plugin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 ![CI workflow](https://github.com/fastify/fastify-rate-limit/workflows/CI%20workflow/badge.svg)
 
-A low overhead rate limiter for your routes. Supports Fastify `2.x` versions.
+A low overhead rate limiter for your routes. Supports Fastify `2.x` and `3.x` versions.
 
 Please refer to [this branch](https://github.com/fastify/fastify-rate-limit/tree/1.x) and related versions for Fastify 1.x compatibility.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 ![CI workflow](https://github.com/fastify/fastify-rate-limit/workflows/CI%20workflow/badge.svg)
 
-A low overhead rate limiter for your routes. Supports Fastify `2.x` and `3.x` versions.
+A low overhead rate limiter for your routes. Supports Fastify `2.x - 3.x` semver range.
 
 Please refer to [this branch](https://github.com/fastify/fastify-rate-limit/tree/1.x) and related versions for Fastify 1.x compatibility.
 

--- a/index.js
+++ b/index.js
@@ -197,6 +197,6 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
 }
 
 module.exports = fp(rateLimitPlugin, {
-  fastify: '2.x - 3.6.0',
+  fastify: '2.x - 3.x',
   name: 'fastify-rate-limit'
 })

--- a/index.js
+++ b/index.js
@@ -197,6 +197,6 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
 }
 
 module.exports = fp(rateLimitPlugin, {
-  fastify: '>=3.x',
+  fastify: '2.x - 3.6.0',
   name: 'fastify-rate-limit'
 })

--- a/index.js
+++ b/index.js
@@ -197,6 +197,6 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
 }
 
 module.exports = fp(rateLimitPlugin, {
-  fastify: '>=2.x',
+  fastify: '>=3.x',
   name: 'fastify-rate-limit'
 })


### PR DESCRIPTION
( firstly thank you the fastify eco system )

Update the plugin version from 2.x to a semver range of 2.x - 3.x. The dependency in package.json indicates fastify version 3. On updating fastify version to a range for the plugin and carrying out integration testing using autocannon to test the change the plugin was found to behave as expected. The package was built locally and published locally via verdaccio.

This was tested locally on node versions
- 10.10.0
- 12.3.1
- 14.1.0



By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin]


There are three sets of tests with the plugin 

- global-rate-limit.test.js	
- route-rate-limit.test.js
- local-store-close.test.js

each has been run to test the change

<img width="1022" alt="Screen Shot 2020-10-13 at 5 45 04 PM" src="https://user-images.githubusercontent.com/5049078/95919720-1c7d1f80-0d7c-11eb-8c0d-24b0e2e0596a.png">
<img width="696" alt="Screen Shot 2020-10-13 at 5 44 45 PM" src="https://user-images.githubusercontent.com/5049078/95919721-1c7d1f80-0d7c-11eb-85a2-00242e7c8b93.png">
<img width="1138" alt="Screen Shot 2020-10-13 at 5 44 33 PM" src="https://user-images.githubusercontent.com/5049078/95919722-1c7d1f80-0d7c-11eb-898a-efd10efbd156.png">

tests via auto cannon using a locally published package.

<img width="1644" alt="Screen Shot 2020-10-13 at 5 10 21 PM" src="https://user-images.githubusercontent.com/5049078/95920100-cb216000-0d7c-11eb-94d4-652e37280d5d.png">
<img width="843" alt="Screen Shot 2020-10-13 at 5 10 04 PM" src="https://user-images.githubusercontent.com/5049078/95920105-cd83ba00-0d7c-11eb-9e74-2bd7fcfcc534.png">

the test harness used was 
```javascript
const fastify = require('fastify')({
  logger: true
})

fastify.register(require('@ghinks/fastify-rate-limit'), {
  max: 10,
  timeWindow: '1 minute'
})

fastify.get('/', (req, reply) => {
  reply.send({ hello: 'world' })
})

fastify.listen(3000, err => {
  if (err) throw err
  console.log('Server listening at http://localhost:3000')
})
```

