### PR TITLE
fix error handler call

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fastify.listen(3000, err => {
 })
 ```
 
-In case a client reaches the maximum number of allowed requests, an error will be send to the user with the status code setted to `429`:
+In case a client reaches the maximum number of allowed requests, an error will be sent to the user with the status code set to `429`:
 ```js
 {
   statusCode: 429,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fastify.listen(3000, err => {
 })
 ```
 
-In case a client reaches the maximum number of allowed requests, a standard Fastify error will be returned to the user with the status code setted to `429`:
+In case a client reaches the maximum number of allowed requests, an error will be send to the user with the status code setted to `429`:
 ```js
 {
   statusCode: 429,
@@ -41,7 +41,16 @@ In case a client reaches the maximum number of allowed requests, a standard Fast
   message: 'Rate limit exceeded, retry in 1 minute'
 }
 ```
-You can change the response by providing a callback to `errorResponseBuilder`.
+You can change the response by providing a callback to `errorResponseBuilder` or setting a [custom error handler](https://www.fastify.io/docs/latest/Server/#seterrorhandler):
+
+```js
+fastify.setErrorHandler(function (error, request, reply) {
+  if (reply.statusCode === 429) {
+    error.message = 'You hit the rate limit! Slow down please!'
+  }
+  reply.send(error)
+})
+```
 
 The response will have some additional headers:
 

--- a/index.js
+++ b/index.js
@@ -162,6 +162,7 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
         }
 
         if (!params.isCustomErrorMessage) {
+          // TODO is this necessary?
           res.type('application/json').serializer(serializeError)
         }
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function rateLimitPlugin (fastify, settings, next) {
     ? settings.keyGenerator
     : (req) => req.ip
 
-  globalParams.errorResponseBuilder = (req, context) => ({ statusCode: context.statusCode, error: 'Too Many Requests', message: `Rate limit exceeded, retry in ${context.after}` })
+  globalParams.errorResponseBuilder = defaultErrorResponse
   globalParams.isCustomErrorMessage = false
 
   // define if error message was overwritten with a custom error response callback
@@ -194,6 +194,13 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
       }
     }
   }
+}
+
+function defaultErrorResponse (req, context) {
+  const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
+  err.statusCode = context.statusCode
+  err.error = 'Too Many Requests'
+  return err
 }
 
 module.exports = fp(rateLimitPlugin, {

--- a/index.js
+++ b/index.js
@@ -1,20 +1,10 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const FJS = require('fast-json-stringify')
 const ms = require('ms')
 
 const LocalStore = require('./store/LocalStore')
 const RedisStore = require('./store/RedisStore')
-
-const serializeError = FJS({
-  type: 'object',
-  properties: {
-    statusCode: { type: 'number' },
-    error: { type: 'string' },
-    message: { type: 'string' }
-  }
-})
 
 function rateLimitPlugin (fastify, settings, next) {
   // create the object that will hold the "main" settings that can be shared during the build
@@ -161,11 +151,6 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
           params.onExceeded(req)
         }
 
-        if (!params.isCustomErrorMessage) {
-          // TODO is this necessary?
-          res.type('application/json').serializer(serializeError)
-        }
-
         if (params.addHeaders['x-ratelimit-limit']) { res.header('x-ratelimit-limit', maximum) }
         if (params.addHeaders['x-ratelimit-remaining']) { res.header('x-ratelimit-remaining', 0) }
         if (params.addHeaders['x-ratelimit-reset']) { res.header('x-ratelimit-reset', Math.floor(ttl / 1000)) }
@@ -200,7 +185,6 @@ function buildRouteRate (pluginComponent, params, routeOptions) {
 function defaultErrorResponse (req, context) {
   const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
   err.statusCode = context.statusCode
-  err.error = 'Too Many Requests'
   return err
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
-    "fast-json-stringify": "^2.2.1",
     "fastify-plugin": "^3.0.0",
     "ms": "^2.1.1",
     "tiny-lru": "^7.0.0"

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -33,7 +33,7 @@ test('Basic', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -82,7 +82,7 @@ test('With text timeWindow', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -253,7 +253,7 @@ test('With redis store', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['x-ratelimit-reset'], 0)
@@ -363,7 +363,7 @@ test('With keyGenerator', t => {
       fastify.inject(payload, (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -434,7 +434,7 @@ test('With CustomStore', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['x-ratelimit-reset'], 7)
@@ -582,7 +582,7 @@ test('hide rate limit headers', t => {
     fastify.inject('/', (err, res) => {
       t.error(err)
       t.strictEqual(res.statusCode, 429)
-      t.strictEqual(res.headers['content-type'], 'application/json')
+      t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
       t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
       t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
       t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -53,7 +53,7 @@ test('Basic', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -106,7 +106,7 @@ test('With text timeWindow', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -251,7 +251,7 @@ test('With redis store', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -363,7 +363,7 @@ test('With keyGenerator', t => {
       fastify.inject(payload, (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['retry-after'], 1000)
@@ -734,7 +734,7 @@ test('hide rate limit headers', t => {
     fastify.inject('/', (err, res) => {
       t.error(err)
       t.strictEqual(res.statusCode, 429)
-      t.strictEqual(res.headers['content-type'], 'application/json')
+      t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
       t.strictEqual(res.headers['x-ratelimit-limit'], 1)
       t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
       t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
@@ -889,7 +889,7 @@ test('With CustomStore', t => {
       fastify.inject('/', (err, res) => {
         t.error(err)
         t.strictEqual(res.statusCode, 429)
-        t.strictEqual(res.headers['content-type'], 'application/json')
+        t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
         t.strictEqual(res.headers['x-ratelimit-limit'], 2)
         t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
         t.strictEqual(res.headers['x-ratelimit-reset'], 7)

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -20,7 +20,7 @@ const defaultRouteConfig = {
 }
 
 test('Basic', t => {
-  t.plan(23)
+  t.plan(24)
   const fastify = Fastify()
   fastify.register(rateLimit, { global: false })
 
@@ -28,6 +28,12 @@ test('Basic', t => {
     config: defaultRouteConfig
   }, (req, reply) => {
     reply.send('hello!')
+  })
+
+  fastify.setErrorHandler(function (error, request, reply) {
+    t.pass('Error handler has been called')
+    error.message += ' from error handler'
+    reply.send(error)
   })
 
   fastify.inject('/', (err, res) => {
@@ -55,7 +61,7 @@ test('Basic', t => {
         t.deepEqual({
           statusCode: 429,
           error: 'Too Many Requests',
-          message: 'Rate limit exceeded, retry in 1 second'
+          message: 'Rate limit exceeded, retry in 1 second from error handler'
         }, JSON.parse(res.payload))
 
         setTimeout(retry, 1100)

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -20,7 +20,7 @@ const defaultRouteConfig = {
 }
 
 test('Basic', t => {
-  t.plan(24)
+  t.plan(25)
   const fastify = Fastify()
   fastify.register(rateLimit, { global: false })
 
@@ -32,6 +32,7 @@ test('Basic', t => {
 
   fastify.setErrorHandler(function (error, request, reply) {
     t.pass('Error handler has been called')
+    t.equals(reply.statusCode, 429)
     error.message += ' from error handler'
     reply.send(error)
   })


### PR DESCRIPTION
Fix #121 

Just a question in the code since it seems to me that a piece of code is no more necessary since the `Error` is managed internally by fastify (for this reason the `application/json` string has changed)