### PR TITLE
fea(#108): Modified rate limit headers following IETF standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ fastify.register(require('fastify-rate-limit'), {
   skipOnError: true, // default false
   keyGenerator: function(req) { /* ... */ }, // default (req) => req.raw.ip
   errorResponseBuilder: function(req, context) { /* ... */},
+  enableDraftSpec: true, // default false. Uses IEFT draft header standard 
   addHeaders: { // default show all the response headers when rate limit is reached
     'x-ratelimit-limit': true,
     'x-ratelimit-remaining': true,
@@ -98,6 +99,7 @@ You can pass a Redis client here and magically the issue is solved. To achieve t
 - `keyGenerator`: a function to generate a unique identifier for each incoming request. Defaults to `(req) => req.ip`, the IP is resolved by fastify using `req.connection.remoteAddress` or `req.headers['x-forwarded-for']` if [trustProxy](https://www.fastify.io/docs/master/Server/#trustproxy) option is enabled. Use it if you want to override this behavior
 - `errorResponseBuilder`: a function to generate a custom response object. Defaults to `(req, context) => ({statusCode: 429, error: 'Too Many Requests', message: ``Rate limit exceeded, retry in ${context.after}``})`
 - `addHeaders`: define which headers should be added in the response when the limit is reached. Defaults all the headers will be shown
+- `enableDraftSpec`: if `true` it will change the HTTP rate limit headers following the IEFT draft document. More information at [draft-ietf-httpapi-ratelimit-headers.md](https://github.com/ietf-wg-httpapi/ratelimit-headers/blob/f6a7bc7560a776ea96d800cf5ed3752d6d397b06/draft-ietf-httpapi-ratelimit-headers.md).
 
 `keyGenerator` example usage:
 ```js
@@ -272,6 +274,19 @@ These examples show an overview of the `store` feature and you should take inspi
 
 - [Knex-SQLite](./example/example-knex.js)
 - [Sequelize-PostgreSQL](./example/example-sequelize.js)
+
+
+### IETF Draft Spec Headers
+
+The response will have the following headers if `enableDraftSpec` is `true`:
+
+
+| Header | Description |
+|--------|-------------|
+|`ratelimit-limit`       | how many request the client can do
+|`ratelimit-remaining`   | how many request remain to the client in the timewindow
+|`ratelimit-reset`       | how many seconds must pass before the rate limit resets
+|`retry-after`           | contains the same value in time as `ratelimit-reset`
 
 <a name="license"></a>
 ## License

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,10 +28,17 @@ export interface FastifyRateLimitStore {
   child(routeOptions: RouteOptions & { path: string, prefix: string }): FastifyRateLimitStore;
 }
 
-interface AddHeaders {
+interface DefaultAddHeaders {
   'x-ratelimit-limit'?: boolean,
   'x-ratelimit-remaining'?: boolean,
   'x-ratelimit-reset'?: boolean,
+  'retry-after'?: boolean
+}
+
+interface DraftSpecAddHeaders {
+  'ratelimit-limit'?: boolean,
+  'ratelimit-remaining'?: boolean,
+  'ratelimit-reset'?: boolean,
   'retry-after'?: boolean
 }
 
@@ -51,7 +58,8 @@ export interface RateLimitPluginOptions {
   ban?: number;
   keyGenerator?: (req: FastifyRequest) => string | number;
   errorResponseBuilder?: (req: FastifyRequest, context: errorResponseBuilderContext) => object;
-  addHeaders?: AddHeaders;
+  addHeaders?: DefaultAddHeaders | DraftSpecAddHeaders;
+  enableDraftSpec?: boolean;
 }
 
 declare const fastifyRateLimit: FastifyPlugin<RateLimitPluginOptions>;

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -976,3 +976,26 @@ test('avoid double onRequest', t => {
     t.equal(keyGeneratorCallCount, 1)
   })
 })
+
+test('With enable IETF draft spec', t => {
+  t.plan(5)
+  const fastify = Fastify()
+  fastify.register(rateLimit, {
+    global: false,
+    enableDraftSpec: true
+  })
+
+  fastify.get('/', {
+    config: defaultRouteConfig
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  fastify.inject('/', (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.strictEqual(res.headers['ratelimit-limit'], 2)
+    t.strictEqual(res.headers['ratelimit-remaining'], 1)
+    t.strictEqual(res.headers['ratelimit-reset'], 1)
+  })
+})


### PR DESCRIPTION
#108 

This PR integrates the IETF standard rate-limit format. You can see the  latest version of the document at [draft-ietf-httpapi-ratelimit-headers.md](https://github.com/ietf-wg-httpapi/ratelimit-headers/blob/f6a7bc7560a776ea96d800cf5ed3752d6d397b06/draft-ietf-httpapi-ratelimit-headers.md).

Considering it's still a draft version, it's possible to activate it optionally using the `enableDraftSpec` parameter. 

List of header which may change:
````
x-ratelimit-limit -> ratelimit-limit
x-ratelimit-remaining -> ratelimit-remaining
x-ratelimit-reset -> ratelimit-reset
````

The documentation uses CamelCase format but fastify only supports LowerCase.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] added `enableDraftSpec` optional parameter
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
