### PR TITLE
Rewrite to async to avoid mixing async and callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/ioredis": "^4.17.0",
     "@types/node": "^14.0.18",
-    "fastify": "^3.0.0",
+    "fastify": "^3.12.0",
     "ioredis": "^4.9.0",
     "knex": "^0.21.1",
     "sqlite3": "^5.0.0",

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -287,12 +287,17 @@ test('Skip on redis error', t => {
   const redis = new Redis({ host: REDIS_HOST })
   fastify.register(rateLimit, {
     redis: redis,
-    global: false,
-    skipError: false
+    global: false
   })
 
   fastify.get('/', {
-    config: defaultRouteConfig
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1000,
+        skipOnError: true
+      }
+    }
   }, (req, reply) => {
     reply.send('hello!')
   })


### PR DESCRIPTION
In https://github.com/fastify/fastify-rate-limit/pull/126, we added the support for using async functions for `max`.
However this left a mixture of promises and callbacks that could cause havoc and made the code harder to understand.
Bonus point: I've found a bug and fixed it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
