### PR TITLE
Add ability to rate limit 404 handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,22 @@ To rate limit your 404 response, you can use a custom handler:
 const fastify = Fastify()
 await fastify.register(rateLimit, { global: true, max: 2, timeWindow: 1000 })
 fastify.setNotFoundHandler({
-  preHandler: fastify.rateLimit
+  preHandler: fastify.rateLimit()
+}, function (request, reply) {
+  reply.code(404).send({ hello: 'world' })
+})
+```
+
+Note that you can customize the behaviour of the preHandler in the same way you would for specific routes:
+
+```js
+const fastify = Fastify()
+await fastify.register(rateLimit, { global: true, max: 2, timeWindow: 1000 })
+fastify.setNotFoundHandler({
+  preHandler: fastify.rateLimit({
+    max: 4,
+    timeWindow: 500
+  })
 }, function (request, reply) {
   reply.code(404).send({ hello: 'world' })
 })

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ The response will have some additional headers:
 |`x-ratelimit-reset`     | how many seconds must pass before the rate limit resets
 |`retry-after`           | if the max has been reached, the millisecond the client must wait before perform new requests
 
+
+### Preventing guessing of URLS through 404s
+
+An attacker could search for valid URLs if your 404 error handling is not rate limited.
+To rate limit your 404 response, you can use a custom handler:
+
+```js
+const fastify = Fastify()
+await fastify.register(rateLimit, { global: true, max: 2, timeWindow: 1000 })
+fastify.setNotFoundHandler({
+  preHandler: fastify.rateLimit
+}, function (request, reply) {
+  reply.code(404).send({ hello: 'world' })
+})
+```
+
 ### Options
 
 You can pass the following options during the plugin registration:
@@ -76,7 +92,7 @@ fastify.register(require('fastify-rate-limit'), {
   skipOnError: true, // default false
   keyGenerator: function(req) { /* ... */ }, // default (req) => req.raw.ip
   errorResponseBuilder: function(req, context) { /* ... */},
-  enableDraftSpec: true, // default false. Uses IEFT draft header standard 
+  enableDraftSpec: true, // default false. Uses IEFT draft header standard
   addHeaders: { // default show all the response headers when rate limit is reached
     'x-ratelimit-limit': true,
     'x-ratelimit-remaining': true,
@@ -211,7 +227,7 @@ fastify.register(require('fastify-rate-limit'),
   {
     global : false, // don't apply these settings to all the routes of the context
     max: 3000, // default global max rate limit
-    allowList: ['192.168.0.10'], // global allowlist access. 
+    allowList: ['192.168.0.10'], // global allowlist access.
     redis: redis, // custom connection to redis
   })
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
     ip: string | number
   }
   interface FastifyInstance {
-    rateLimit: (options?:RateLimitPluginOptions) => preHandlerAsyncHookHandler;
+    rateLimit: (options?:RateLimitOptions) => preHandlerAsyncHookHandler;
   }
 }
 
@@ -45,8 +45,7 @@ interface DraftSpecAddHeaders {
   'retry-after'?: boolean
 }
 
-export interface RateLimitPluginOptions {
-  global?: boolean;
+export interface RateLimitOptions {
   max?: number | ((req: FastifyRequest, key: string) => number);
   timeWindow?: number | string;
   cache?: number;
@@ -56,13 +55,18 @@ export interface RateLimitPluginOptions {
   */
   whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);
   allowList?: string[] | ((req: FastifyRequest, key: string) => boolean);
-  redis?: any;
   skipOnError?: boolean;
   ban?: number;
   keyGenerator?: (req: FastifyRequest) => string | number;
   errorResponseBuilder?: (req: FastifyRequest, context: errorResponseBuilderContext) => object;
-  addHeaders?: DefaultAddHeaders | DraftSpecAddHeaders;
   enableDraftSpec?: boolean;
+}
+
+export interface RateLimitPluginOptions extends RateLimitOptions {
+  global?: boolean;
+  cache?: number;
+  redis?: any;
+  addHeaders?: DefaultAddHeaders | DraftSpecAddHeaders;
 }
 
 declare const fastifyRateLimit: FastifyPlugin<RateLimitPluginOptions>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { FastifyPlugin, FastifyRequest, RouteOptions, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestGenericInterface } from 'fastify';
+import { FastifyPlugin, FastifyRequest, RouteOptions, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestGenericInterface, preHandlerAsyncHookHandler } from 'fastify';
 
 declare module 'fastify' {
   interface FastifyRequestInterface<
@@ -9,6 +9,9 @@ declare module 'fastify' {
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface
     > {
     ip: string | number
+  }
+  interface FastifyInstance {
+    rateLimit: preHandlerAsyncHookHandler;
   }
 }
 
@@ -49,7 +52,7 @@ export interface RateLimitPluginOptions {
   cache?: number;
   store?: FastifyRateLimitStoreCtor;
   /**
-  * @deprecated Use `allowList` property 
+  * @deprecated Use `allowList` property
   */
   whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);
   allowList?: string[] | ((req: FastifyRequest, key: string) => boolean);

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
     ip: string | number
   }
   interface FastifyInstance {
-    rateLimit: preHandlerAsyncHookHandler;
+    rateLimit: () => preHandlerAsyncHookHandler;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
     ip: string | number
   }
   interface FastifyInstance {
-    rateLimit: () => preHandlerAsyncHookHandler;
+    rateLimit: (options?:RateLimitPluginOptions) => preHandlerAsyncHookHandler;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,13 @@ async function rateLimitPlugin (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     // The rate limit plugin can be registered multiple times but decorate throws if called multiple times for the same field
-    fastify.decorate('rateLimit', function rateLimit () { return rateLimitRequestHandler(globalParams, pluginComponent) })
+    fastify.decorate('rateLimit', function rateLimit (options) {
+      let params = globalParams
+      if (options) {
+        params = makeParams(options)
+      }
+      return rateLimitRequestHandler(params, pluginComponent)
+    })
   }
 
   // onRoute add the onRequest rate-limit function if needed

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ async function rateLimitPlugin (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     // The rate limit plugin can be registered multiple times but decorate throws if called multiple times for the same field
-    fastify.decorate('rateLimit', rateLimitRequestHandler(globalParams, pluginComponent))
+    fastify.decorate('rateLimit', function rateLimit () { return rateLimitRequestHandler(globalParams, pluginComponent) })
   }
 
   // onRoute add the onRequest rate-limit function if needed

--- a/index.js
+++ b/index.js
@@ -90,7 +90,11 @@ async function rateLimitPlugin (fastify, settings) {
   const run = Symbol('rate-limit-did-run')
   pluginComponent.run = run
   fastify.decorateRequest(run, false)
-  fastify.decorate('rateLimit', rateLimitRequestHandler(globalParams, pluginComponent))
+
+  if (!fastify.hasDecorator('rateLimit')) {
+    // The rate limit plugin can be registered multiple times but decorate throws if called multiple times for the same field
+    fastify.decorate('rateLimit', rateLimitRequestHandler(globalParams, pluginComponent))
+  }
 
   // onRoute add the onRequest rate-limit function if needed
   fastify.addHook('onRoute', (routeOptions) => {

--- a/test/not-found-handler-rate-limited.js
+++ b/test/not-found-handler-rate-limited.js
@@ -46,3 +46,60 @@ test('Set not found handler can be rate limited', async t => {
     message: 'Rate limit exceeded, retry in 1 second'
   })
 })
+
+test('Set not found handler can be rate limited with specific options', async t => {
+  t.plan(28)
+
+  const fastify = Fastify()
+
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
+  t.ok(fastify.rateLimit)
+
+  fastify.setNotFoundHandler({
+    preHandler: fastify.rateLimit({
+      max: 4,
+      timeWindow: 2000
+    })
+  }, function (request, reply) {
+    t.pass('Error handler has been called')
+    reply.status(404).send(new Error('Not found'))
+  })
+
+  let res
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 4)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 3)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 1)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 4)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 2)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 4)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 4)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 429)
+  t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.strictEqual(res.headers['x-ratelimit-limit'], 4)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+  t.strictEqual(res.headers['retry-after'], 2000)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+  t.deepEqual(JSON.parse(res.payload), {
+    statusCode: 429,
+    error: 'Too Many Requests',
+    message: 'Rate limit exceeded, retry in 2 seconds'
+  })
+})

--- a/test/not-found-handler-rate-limited.js
+++ b/test/not-found-handler-rate-limited.js
@@ -5,60 +5,44 @@ const test = t.test
 const Fastify = require('fastify')
 const rateLimit = require('../index')
 
-test('Set not found handler can be rate limited', t => {
-  t.plan(27)
+test('Set not found handler can be rate limited', async t => {
+  t.plan(18)
+
   const fastify = Fastify()
-  fastify.register(rateLimit, { max: 2, timeWindow: 1000 }).then(() => {
-    t.ok(fastify.rateLimit)
 
-    fastify.setNotFoundHandler({
-      preHandler: fastify.rateLimit
-    }, function (request, reply) {
-      t.pass('Error handler has been called')
-      reply.status(404).send(new Error('Not found'))
-    })
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
+  t.ok(fastify.rateLimit)
 
-    fastify.inject('/not-found', (err, res) => {
-      t.error(err)
-      t.strictEqual(res.statusCode, 404)
-      t.strictEqual(res.headers['x-ratelimit-limit'], 2)
-      t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
-      t.strictEqual(res.headers['x-ratelimit-reset'], 1)
-
-      fastify.inject('/not-found', (err, res) => {
-        t.error(err)
-        t.strictEqual(res.statusCode, 404)
-        t.strictEqual(res.headers['x-ratelimit-limit'], 2)
-        t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
-        t.strictEqual(res.headers['x-ratelimit-reset'], 0)
-
-        fastify.inject('/not-found', (err, res) => {
-          t.error(err)
-          t.strictEqual(res.statusCode, 429)
-          t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
-          t.strictEqual(res.headers['x-ratelimit-limit'], 2)
-          t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
-          t.strictEqual(res.headers['retry-after'], 1000)
-          t.strictEqual(res.headers['x-ratelimit-reset'], 0)
-          t.deepEqual(JSON.parse(res.payload), {
-            statusCode: 429,
-            error: 'Too Many Requests',
-            message: 'Rate limit exceeded, retry in 1 second'
-          })
-
-          setTimeout(retry, 1100)
-        })
-      })
-    })
+  fastify.setNotFoundHandler({
+    preHandler: fastify.rateLimit()
+  }, function (request, reply) {
+    t.pass('Error handler has been called')
+    reply.status(404).send(new Error('Not found'))
   })
 
-  function retry () {
-    fastify.inject('/not-found', (err, res) => {
-      t.error(err)
-      t.strictEqual(res.statusCode, 404)
-      t.strictEqual(res.headers['x-ratelimit-limit'], 2)
-      t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
-      t.strictEqual(res.headers['x-ratelimit-reset'], 1)
-    })
-  }
+  let res
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 1)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 404)
+  t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+
+  res = await fastify.inject('/not-found')
+  t.strictEqual(res.statusCode, 429)
+  t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+  t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+  t.strictEqual(res.headers['retry-after'], 1000)
+  t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+  t.deepEqual(JSON.parse(res.payload), {
+    statusCode: 429,
+    error: 'Too Many Requests',
+    message: 'Rate limit exceeded, retry in 1 second'
+  })
 })

--- a/test/not-found-handler-rate-limited.js
+++ b/test/not-found-handler-rate-limited.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const rateLimit = require('../index')
+
+test('Set not found handler can be rate limited', t => {
+  t.plan(27)
+  const fastify = Fastify()
+  fastify.register(rateLimit, { max: 2, timeWindow: 1000 }).then(() => {
+
+    t.ok(fastify.rateLimit)
+
+    fastify.setNotFoundHandler({
+      preHandler: fastify.rateLimit
+    }, function (request, reply) {
+      t.pass('Error handler has been called')
+      reply.status(404).send(new Error('Not found'))
+    })
+
+    fastify.inject('/not-found', (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 404)
+      t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+      t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+      t.strictEqual(res.headers['x-ratelimit-reset'], 1)
+
+      fastify.inject('/not-found', (err, res) => {
+        t.error(err)
+        t.strictEqual(res.statusCode, 404)
+        t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+        t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+        t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+
+        fastify.inject('/not-found', (err, res) => {
+          t.error(err)
+          t.strictEqual(res.statusCode, 429)
+          t.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+          t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+          t.strictEqual(res.headers['x-ratelimit-remaining'], 0)
+          t.strictEqual(res.headers['retry-after'], 1000)
+          t.strictEqual(res.headers['x-ratelimit-reset'], 0)
+          t.deepEqual(JSON.parse(res.payload), {
+            statusCode: 429,
+            error: 'Too Many Requests',
+            message: 'Rate limit exceeded, retry in 1 second'
+          })
+
+          setTimeout(retry, 1100)
+        })
+      })
+    })
+  })
+
+  function retry () {
+    fastify.inject('/not-found', (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 404)
+      t.strictEqual(res.headers['x-ratelimit-limit'], 2)
+      t.strictEqual(res.headers['x-ratelimit-remaining'], 1)
+      t.strictEqual(res.headers['x-ratelimit-reset'], 1)
+    })
+  }
+})

--- a/test/not-found-handler-rate-limited.js
+++ b/test/not-found-handler-rate-limited.js
@@ -9,7 +9,6 @@ test('Set not found handler can be rate limited', t => {
   t.plan(27)
   const fastify = Fastify()
   fastify.register(rateLimit, { max: 2, timeWindow: 1000 }).then(() => {
-
     t.ok(fastify.rateLimit)
 
     fastify.setNotFoundHandler({

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -49,7 +49,10 @@ appWithImplicitHttp.register(fastifyRateLimit, options1)
 appWithImplicitHttp.register(fastifyRateLimit, options2)
 
 appWithImplicitHttp.register(fastifyRateLimit, options3).then(() => {
-  const preHandler:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit()
+  const preHandler1:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit()
+  const preHandler2:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options1)
+  const preHandler3:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options2)
+  const preHandler4:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options3)
   // The following test is dependent on https://github.com/fastify/fastify/pull/2929
   // appWithImplicitHttp.setNotFoundHandler({
   //   preHandler: appWithImplicitHttp.rateLimit()

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,6 +1,5 @@
-import * as http from 'http'
 import * as http2 from 'http2'
-import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface } from 'fastify';
+import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface, FastifyReply, preHandlerAsyncHookHandler } from 'fastify';
 import * as ioredis from 'ioredis';
 import fastifyRateLimit, { FastifyRateLimitStore, FastifyRateLimitOptions, errorResponseBuilderContext, RateLimitPluginOptions } from '../../';
 
@@ -48,7 +47,17 @@ const options3 = {
 
 appWithImplicitHttp.register(fastifyRateLimit, options1)
 appWithImplicitHttp.register(fastifyRateLimit, options2)
-appWithImplicitHttp.register(fastifyRateLimit, options3)
+
+appWithImplicitHttp.register(fastifyRateLimit, options3).then(() => {
+  const preHandler:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit()
+  // The following test is dependent on https://github.com/fastify/fastify/pull/2929
+  // appWithImplicitHttp.setNotFoundHandler({
+  //   preHandler: appWithImplicitHttp.rateLimit()
+  // }, function (request:FastifyRequest<RequestGenericInterface>, reply: FastifyReply<ReplyGenericInterface>) {
+  //   reply.status(404).send(new Error('Not found'))
+  // })
+})
+
 
 const appWithHttp2: FastifyInstance<
   http2.Http2Server,


### PR DESCRIPTION
Addresses #127

This adds the ability for users to rate limit the setNotFoundHandler.
An attacker could search for valid URLs if your 404 error handling is not rate limited.

#### Checklist

- [ x] run `npm run test` ~and `npm run benchmark`~ (comment: `benchmark` script does not exist)
- [ x] tests and/or benchmarks are included
- [ x] documentation is changed or added
- [ x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
