### PR TITLE
Add TTL to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ fastify.register(require('fastify-rate-limit'), {
       code: 429,
       error: 'Too Many Requests',
       message: `I only allow ${context.max} requests per ${context.after} to this Website. Try again soon.`,
-      date: Date.now()
+      date: Date.now(),
+      expiresIn: context.ttl // milliseconds
     }
   }
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export interface FastifyRateLimitOptions { }
 export interface errorResponseBuilderContext {
   after: string;
   max: number;
+  ttl: number;
 }
 
 export interface FastifyRateLimitStoreCtor {

--- a/index.js
+++ b/index.js
@@ -231,7 +231,8 @@ function rateLimitRequestHandler (params, pluginComponent) {
     const respCtx = {
       statusCode: code,
       after,
-      max: maximum
+      max: maximum,
+      ttl
     }
 
     if (code === 403) {


### PR DESCRIPTION
This PR enables access to the TTL of a cache entry within the `errorResponseBuilder` context.

Example usage:
```ts
app.register(fastifyRateLimit, {
  errorResponseBuilder: (_req, context) => ({
    code: 'rate_limited',
    retry_after: context.ttl / 1000
  }),
})
```

Resulting output:
```jsonc
{
  "code": "rate_limited",
  "retry_after": 3599.594 // seconds (context.ttl / 1000)
}
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)