### PR TITLE
Fixing `continueExceeding` option does not reset rate-limit - #207

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,14 @@ function rateLimitRequestHandler (params, pluginComponent) {
     let current = 0
     let ttl = 0
 
+    let maximum
+
+    if (typeof params.max === 'number' && !isNaN(params.max)) {
+      maximum = params.max
+    } else {
+      maximum = await params.max(req, key)
+    }
+
     // As the key is not allowList in redis/lru, then we increment the rate-limit of the current request
     try {
       const res = await new Promise(function (resolve, reject) {
@@ -195,7 +203,7 @@ function rateLimitRequestHandler (params, pluginComponent) {
             return
           }
           resolve(res)
-        })
+        }, maximum)
       })
 
       current = res.current
@@ -204,14 +212,6 @@ function rateLimitRequestHandler (params, pluginComponent) {
       if (!params.skipOnError) {
         throw err
       }
-    }
-
-    let maximum
-
-    if (typeof params.max === 'number' && !isNaN(params.max)) {
-      maximum = params.max
-    } else {
-      maximum = await params.max(req, key)
     }
 
     const timeLeft = Math.floor(ttl / 1000)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
-    "@sinonjs/fake-timers": "^9.1.0",
     "fastify-plugin": "^3.0.0",
     "ms": "^2.1.1",
     "tiny-lru": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
+    "@sinonjs/fake-timers": "^9.1.0",
     "fastify-plugin": "^3.0.0",
     "ms": "^2.1.1",
     "tiny-lru": "^8.0.1"

--- a/test/github-issues/issue-207.test.js
+++ b/test/github-issues/issue-207.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const rateLimit = require('../../index')
+
+test('issue #207 - when continueExceeding is true and the store is local then it should reset the rate-limit', async t => {
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+  const fastify = Fastify()
+
+  fastify.register(rateLimit, {
+    global: false
+  })
+
+  fastify.get('/', {
+    config: {
+      rateLimit: {
+        max: 1,
+        timeWindow: 5000,
+        continueExceeding: true
+      }
+    }
+  }, async () => {
+    return 'hello!'
+  })
+
+  const firstOkResponse = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+  const firstRateLimitResponse = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  await sleep(3000)
+
+  const secondRateLimitWithResettingTheRateLimitTimer = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  // after this the total time passed is 6s which WITHOUT `continueExceeding` the next request should be OK
+  await sleep(3000)
+
+  const thirdRateLimitWithResettingTheRateLimitTimer = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  // After this the rate limiter should allow for new requests
+  await sleep(5000)
+
+  const okResponseAfterRateLimitCompleted = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  t.equal(firstOkResponse.statusCode, 200)
+
+  t.equal(firstRateLimitResponse.statusCode, 429)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-limit'], 1)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-remaining'], 0)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-reset'], 5)
+
+  t.equal(secondRateLimitWithResettingTheRateLimitTimer.statusCode, 429)
+  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'], 1)
+  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-remaining'], 0)
+  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'], 5)
+
+  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.statusCode, 429)
+  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'], 1)
+  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-remaining'], 0)
+  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'], 5)
+
+  t.equal(okResponseAfterRateLimitCompleted.statusCode, 200)
+})


### PR DESCRIPTION
also changed the package.json so tap would run all the tests in the test folder and it's sub directories

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

fix #207
