### PR TITLE
Clean tests

### DIFF
--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -389,8 +389,8 @@ test('With CustomStore', async t => {
   }, JSON.parse(res.payload))
 })
 
-test('does not override the onRequest', t => {
-  t.plan(5)
+test('does not override the onRequest', async t => {
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 2,
@@ -402,16 +402,12 @@ test('does not override the onRequest', t => {
       t.pass('onRequest called')
       next()
     }
-  }, (req, reply) => {
-    reply.send('hello!')
-  })
+  }, async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], 2)
-    t.equal(res.headers['x-ratelimit-remaining'], 1)
-  })
+  const res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
 test('does not override the onRequest as an array', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -626,32 +626,26 @@ test('hide rate limit headers at all times', async t => {
   t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
 })
 
-test('With ban', t => {
-  t.plan(6)
+test('With ban', async t => {
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 1,
     ban: 1
   })
 
-  fastify.get('/', (req, reply) => {
-    reply.send('hello!')
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 429)
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 
-      fastify.inject('/', (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 403)
-      })
-    })
-  })
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 403)
 })
 
 test('stops fastify lifecycle after onRequest and before preValidation', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -488,8 +488,8 @@ test('variable max contenders', async t => {
   }
 })
 
-test('hide rate limit headers', t => {
-  t.plan(17)
+test('hide rate limit headers', async t => {
+  t.plan(14)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 1,
@@ -502,37 +502,34 @@ test('hide rate limit headers', t => {
     }
   })
 
-  fastify.get('/', (req, res) => { res.send('hello') })
+  fastify.get('/', async (req, res) => 'hello')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], 1)
-    t.equal(res.headers['x-ratelimit-remaining'], 0)
-    t.equal(res.headers['x-ratelimit-reset'], 1)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 429)
-      t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-      t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-      t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-      t.notOk(res.headers['retry-after'], 'the header must be missing')
+  res = await fastify.inject('/')
 
-      setTimeout(retry, 1100)
-    })
-  })
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 1)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.equal(res.headers['x-ratelimit-reset'], 1)
 
-  function retry () {
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.equal(res.headers['x-ratelimit-limit'], 1)
-      t.equal(res.headers['x-ratelimit-remaining'], 0)
-      t.equal(res.headers['x-ratelimit-reset'], 1)
-    })
-  }
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 429)
+  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
+  t.notOk(res.headers['retry-after'], 'the header must be missing')
+
+  // TODO - use sinom timers
+  await sleep(1100)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 1)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.equal(res.headers['x-ratelimit-reset'], 1)
 })
 
 test('hide rate limit headers on exceeding', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -98,8 +98,8 @@ test('With text timeWindow', async t => {
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
-test('With ips allowList', t => {
-  t.plan(6)
+test('With ips allowList', async t => {
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 2,
@@ -107,28 +107,22 @@ test('With ips allowList', t => {
     allowList: ['127.0.0.1']
   })
 
-  fastify.get('/', (req, reply) => {
-    reply.send('hello!')
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 
-      fastify.inject('/', (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 200)
-      })
-    })
-  })
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 })
 
-test('With ips whitelist', t => {
-  t.plan(6)
+test('With ips whitelist', async t => {
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 2,
@@ -136,28 +130,22 @@ test('With ips whitelist', t => {
     whitelist: ['127.0.0.1']
   })
 
-  fastify.get('/', (req, reply) => {
-    reply.send('hello!')
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 
-      fastify.inject('/', (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 200)
-      })
-    })
-  })
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 })
 
-test('With function allowList', t => {
-  t.plan(24)
+test('With function allowList', async t => {
+  t.plan(18)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 2,
@@ -170,9 +158,7 @@ test('With function allowList', t => {
     }
   })
 
-  fastify.get('/', (req, reply) => {
-    reply.send('hello!')
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
   const allowListHeader = {
     method: 'GET',
@@ -182,35 +168,25 @@ test('With function allowList', t => {
     }
   }
 
-  fastify.inject(allowListHeader, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  let res
 
-    fastify.inject(allowListHeader, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
+  res = await fastify.inject(allowListHeader)
+  t.equal(res.statusCode, 200)
 
-      fastify.inject(allowListHeader, (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 200)
-      })
-    })
-  })
+  res = await fastify.inject(allowListHeader)
+  t.equal(res.statusCode, 200)
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  res = await fastify.inject(allowListHeader)
+  t.equal(res.statusCode, 200)
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
 
-      fastify.inject('/', (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 429)
-      })
-    })
-  })
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
 })
 
 test('With redis store', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -54,53 +54,48 @@ test('Basic', async t => {
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
-test('With text timeWindow', t => {
-  t.plan(19)
+test('With text timeWindow', async t => {
+  t.plan(15)
   const fastify = Fastify()
   fastify.register(rateLimit, { max: 2, timeWindow: '1s' })
 
-  fastify.get('/', (req, reply) => {
-    reply.send('hello!')
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], 2)
-    t.equal(res.headers['x-ratelimit-remaining'], 1)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.equal(res.headers['x-ratelimit-limit'], 2)
-      t.equal(res.headers['x-ratelimit-remaining'], 0)
+  res = await fastify.inject('/')
 
-      fastify.inject('/', (err, res) => {
-        t.error(err)
-        t.equal(res.statusCode, 429)
-        t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-        t.equal(res.headers['x-ratelimit-limit'], 2)
-        t.equal(res.headers['x-ratelimit-remaining'], 0)
-        t.equal(res.headers['retry-after'], 1000)
-        t.same({
-          statusCode: 429,
-          error: 'Too Many Requests',
-          message: 'Rate limit exceeded, retry in 1 second'
-        }, JSON.parse(res.payload))
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 1)
 
-        setTimeout(retry, 1100)
-      })
-    })
-  })
+  res = await fastify.inject('/')
 
-  function retry () {
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.equal(res.headers['x-ratelimit-limit'], 2)
-      t.equal(res.headers['x-ratelimit-remaining'], 1)
-    })
-  }
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 429)
+  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.equal(res.headers['retry-after'], 1000)
+  t.same({
+    statusCode: 429,
+    error: 'Too Many Requests',
+    message: 'Rate limit exceeded, retry in 1 second'
+  }, JSON.parse(res.payload))
+
+  // TODO - use sinom timers
+  await sleep(1100)
+
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
 test('With ips allowList', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -830,9 +830,7 @@ test('exposeHeadRoutes', async t => {
     max: 10,
     timeWindow: 1000
   })
-  fastify.get('/', async (req, reply) => {
-    return 'hello!'
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
   const res = await fastify.inject({
     url: '/',

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -812,12 +812,12 @@ test('afterReset and Rate Limit remain the same when enableDraftSpec is enabled'
 test('Before async in "max"', async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {
-    keyGenerator (req) { return req.headers['api-key'] },
-    max: async (req, key) => { return requestSequence(key) },
+    keyGenerator: (req) => req.headers['api-key'],
+    max: async (req, key) => requestSequence(key),
     timeWindow: 10000
   })
 
-  await fastify.get('/', (req, res) => { res.send('hello') })
+  await fastify.get('/', async (req, res) => 'hello')
 
   const requestSequence = async (key) => await key === 'pro' ? 5 : 2
 })

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -532,8 +532,8 @@ test('hide rate limit headers', async t => {
   t.equal(res.headers['x-ratelimit-reset'], 1)
 })
 
-test('hide rate limit headers on exceeding', t => {
-  t.plan(17)
+test('hide rate limit headers on exceeding', async t => {
+  t.plan(14)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 1,
@@ -545,37 +545,35 @@ test('hide rate limit headers on exceeding', t => {
     }
   })
 
-  fastify.get('/', (req, res) => { res.send('hello') })
+  fastify.get('/', async (req, res) => 'hello')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-    t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-    t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 429)
-      t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-      t.equal(res.headers['x-ratelimit-limit'], 1)
-      t.equal(res.headers['x-ratelimit-remaining'], 0)
-      t.not(res.headers['x-ratelimit-reset'], undefined)
-      t.equal(res.headers['retry-after'], 1000)
+  res = await fastify.inject('/')
 
-      setTimeout(retry, 1100)
-    })
-  })
+  t.equal(res.statusCode, 200)
+  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
 
-  function retry () {
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-      t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-      t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-    })
-  }
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 429)
+  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.equal(res.headers['x-ratelimit-limit'], 1)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.not(res.headers['x-ratelimit-reset'], undefined)
+  t.equal(res.headers['retry-after'], 1000)
+
+  // TODO - use sinom timers
+  await sleep(1100)
+
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 200)
+  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
+  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
 })
 
 test('hide rate limit headers at all times', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -860,9 +860,7 @@ test('When continue exceeding is on (Local)', async t => {
     continueExceeding: true
   })
 
-  fastify.get('/', async (req, reply) => {
-    return 'hello!'
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
   const first = await fastify.inject({
     url: '/',
@@ -893,9 +891,7 @@ test('When continue exceeding is on (Redis)', async t => {
     continueExceeding: true
   })
 
-  fastify.get('/', async (req, reply) => {
-    return 'hello!'
-  })
+  fastify.get('/', async (req, reply) => 'hello!')
 
   const first = await fastify.inject({
     url: '/',

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -432,8 +432,8 @@ test('does not override the onRequest as an array', async t => {
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
-test('variable max', t => {
-  t.plan(5)
+test('variable max', async t => {
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: (req, key) => {
@@ -443,14 +443,13 @@ test('variable max', t => {
     timeWindow: 1000
   })
 
-  fastify.get('/', (req, res) => { res.send('hello') })
+  fastify.get('/', async (req, res) => 'hello')
 
-  fastify.inject({ url: '/', headers: { 'secret-max': 50 } }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], 50)
-    t.equal(res.headers['x-ratelimit-remaining'], 49)
-  })
+  const res = await fastify.inject({ url: '/', headers: { 'secret-max': 50 } })
+
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 50)
+  t.equal(res.headers['x-ratelimit-remaining'], 49)
 })
 
 test('variable max contenders', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -648,8 +648,8 @@ test('With ban', async t => {
   t.equal(res.statusCode, 403)
 })
 
-test('stops fastify lifecycle after onRequest and before preValidation', t => {
-  t.plan(6)
+test('stops fastify lifecycle after onRequest and before preValidation', async t => {
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(rateLimit, { max: 1, timeWindow: 1000 })
 
@@ -662,20 +662,16 @@ test('stops fastify lifecycle after onRequest and before preValidation', t => {
       next()
     }
   },
-  (req, reply) => {
-    reply.send('hello!')
-  })
+  async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  let res
 
-    fastify.inject('/', (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 429)
-      t.equal(preValidationCallCount, 1)
-    })
-  })
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+  t.equal(preValidationCallCount, 1)
 })
 
 test('With enabled IETF Draft Spec', t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -410,8 +410,8 @@ test('does not override the onRequest', async t => {
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
-test('does not override the onRequest as an array', t => {
-  t.plan(5)
+test('does not override the onRequest as an array', async t => {
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(rateLimit, {
     max: 2,
@@ -423,16 +423,13 @@ test('does not override the onRequest as an array', t => {
       t.pass('onRequest called')
       next()
     }]
-  }, (req, reply) => {
-    reply.send('hello!')
-  })
+  }, async (req, reply) => 'hello!')
 
-  fastify.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], 2)
-    t.equal(res.headers['x-ratelimit-remaining'], 1)
-  })
+  const res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 1)
 })
 
 test('variable max', t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


----

I'll clean the rest of the tests, just wanted to know if it's a desirable change, no logic has been changed


For easier review, I advise you to check the _Hide whitespace_ checkbox

![image](https://user-images.githubusercontent.com/16746759/153419179-aca24d23-4beb-4282-b644-c04d550c2a7d.png)
