### PR TITLE
test: fix 'enabled-IETF-draft-spec' test

### DIFF
--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -711,7 +711,7 @@ test('With enabled IETF Draft Spec', async t => {
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['ratelimit-limit'], 2)
   t.equal(res.headers['ratelimit-remaining'], 0)
-  t.equal(res.headers['ratelimit-remaining'], res.headers['retry-after'])
+  t.equal(res.headers['ratelimit-reset'], res.headers['retry-after'])
   const { ttl, ...payload } = JSON.parse(res.payload)
   t.equal(res.headers['retry-after'], Math.floor(ttl / 1000))
   t.same({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

According to the docs in [IETF Draft Spec Headers](https://github.com/fastify/fastify-rate-limit#ietf-draft-spec-headers), when `enableDraftSpec` is `true` then:
> `ratelimit-reset`: how many seconds must pass before the rate limit resets
> `retry-after`: contains the **same value in time as `ratelimit-reset`**


and the test checked that the `ratelimit-remaining` header is equal to `retry-after`
