### PR TITLE
fix (types): fix typescript tests and update typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,30 @@
-/// <reference types="node" />
+/// <reference types='node' />
 
-import { FastifyPlugin, FastifyRequest, RouteOptions, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RequestGenericInterface, preHandlerAsyncHookHandler } from 'fastify';
+import {
+  FastifyPluginCallback,
+  FastifyRequest,
+  preHandlerAsyncHookHandler,
+  RawRequestDefaultExpression,
+  RawServerBase,
+  RawServerDefault,
+  RequestGenericInterface,
+  RouteOptions
+} from 'fastify';
 
 declare module 'fastify' {
   interface FastifyRequestInterface<
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
     RequestGeneric extends RequestGenericInterface = RequestGenericInterface
-    > {
-    ip: string | number
+  > {
+    ip: string | number;
   }
   interface FastifyInstance {
-    rateLimit: (options?:RateLimitOptions) => preHandlerAsyncHookHandler;
+    rateLimit: (options?: RateLimitOptions) => preHandlerAsyncHookHandler;
   }
 }
 
-export interface FastifyRateLimitOptions { }
+export interface FastifyRateLimitOptions {}
 
 export interface errorResponseBuilderContext {
   after: string;
@@ -24,55 +33,69 @@ export interface errorResponseBuilderContext {
 }
 
 export interface FastifyRateLimitStoreCtor {
-  new(options: FastifyRateLimitOptions): FastifyRateLimitStore;
+  new (options: FastifyRateLimitOptions): FastifyRateLimitStore;
 }
 
 export interface FastifyRateLimitStore {
-  incr(key: string, callback: (error: Error | null, result?: { current: number, ttl: number }) => void): void;
-  child(routeOptions: RouteOptions & { path: string, prefix: string }): FastifyRateLimitStore;
+  incr(
+    key: string,
+    callback: (
+      error: Error | null,
+      result?: { current: number; ttl: number }
+    ) => void
+  ): void;
+  child(
+    routeOptions: RouteOptions & { path: string; prefix: string }
+  ): FastifyRateLimitStore;
 }
 
 interface DefaultAddHeaders {
-  'x-ratelimit-limit'?: boolean,
-  'x-ratelimit-remaining'?: boolean,
-  'x-ratelimit-reset'?: boolean,
-  'retry-after'?: boolean
+  'x-ratelimit-limit'?: boolean;
+  'x-ratelimit-remaining'?: boolean;
+  'x-ratelimit-reset'?: boolean;
+  'retry-after'?: boolean;
 }
 
 interface DraftSpecAddHeaders {
-  'ratelimit-limit'?: boolean,
-  'ratelimit-remaining'?: boolean,
-  'ratelimit-reset'?: boolean,
-  'retry-after'?: boolean
+  'ratelimit-limit'?: boolean;
+  'ratelimit-remaining'?: boolean;
+  'ratelimit-reset'?: boolean;
+  'retry-after'?: boolean;
 }
 
 interface DefaultAddHeadersOnExceeding {
-  'x-ratelimit-limit'?: boolean,
-  'x-ratelimit-remaining'?: boolean,
-  'x-ratelimit-reset'?: boolean
+  'x-ratelimit-limit'?: boolean;
+  'x-ratelimit-remaining'?: boolean;
+  'x-ratelimit-reset'?: boolean;
 }
 
 interface DraftSpecAddHeadersOnExceeding {
-  'ratelimit-limit'?: boolean,
-  'ratelimit-remaining'?: boolean,
-  'ratelimit-reset'?: boolean
+  'ratelimit-limit'?: boolean;
+  'ratelimit-remaining'?: boolean;
+  'ratelimit-reset'?: boolean;
 }
 
 export interface RateLimitOptions {
-  max?: number | ((req: FastifyRequest, key: string) => number) | ((req: FastifyRequest, key: string) => Promise<number>);
+  max?:
+    | number
+    | ((req: FastifyRequest, key: string) => number)
+    | ((req: FastifyRequest, key: string) => Promise<number>);
   timeWindow?: number | string;
   cache?: number;
   store?: FastifyRateLimitStoreCtor;
   /**
-  * @deprecated Use `allowList` property
-  */
+   * @deprecated Use `allowList` property
+   */
   whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);
   allowList?: string[] | ((req: FastifyRequest, key: string) => boolean);
   continueExceeding?: boolean;
   skipOnError?: boolean;
   ban?: number;
   keyGenerator?: (req: FastifyRequest) => string | number;
-  errorResponseBuilder?: (req: FastifyRequest, context: errorResponseBuilderContext) => object;
+  errorResponseBuilder?: (
+    req: FastifyRequest,
+    context: errorResponseBuilderContext
+  ) => object;
   enableDraftSpec?: boolean;
 }
 
@@ -81,9 +104,10 @@ export interface RateLimitPluginOptions extends RateLimitOptions {
   cache?: number;
   redis?: any;
   addHeaders?: DefaultAddHeaders | DraftSpecAddHeaders;
-  addHeadersOnExceeding?: DefaultAddHeadersOnExceeding | DraftSpecAddHeadersOnExceeding;
+  addHeadersOnExceeding?:
+    | DefaultAddHeadersOnExceeding
+    | DraftSpecAddHeadersOnExceeding;
 }
 
-declare const fastifyRateLimit: FastifyPlugin<RateLimitPluginOptions>;
-
+declare const fastifyRateLimit: FastifyPluginCallback<RateLimitPluginOptions>;
 export default fastifyRateLimit;

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
   "homepage": "https://github.com/fastify/fastify-rate-limit#readme",
   "devDependencies": {
     "@sinonjs/fake-timers": "^9.1.0",
-    "@types/ioredis": "^4.17.0",
-    "@types/node": "^17.0.0",
-    "fastify": "^3.12.0",
-    "ioredis": "^4.9.0",
-    "knex": "^1.0.1",
-    "sqlite3": "^5.0.0",
-    "standard": "^16.0.2",
-    "tap": "^15.0.1",
-    "tsd": "^0.14.0"
+    "@types/ioredis": "^4.28.8",
+    "@types/node": "^17.0.21",
+    "fastify": "^3.27.2",
+    "ioredis": "^4.28.5",
+    "knex": "^1.0.3",
+    "sqlite3": "^5.0.2",
+    "standard": "^16.0.4",
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.0",
-    "ms": "^2.1.1",
+    "fastify-plugin": "^3.0.1",
+    "ms": "^2.1.3",
     "tiny-lru": "^8.0.1"
   },
   "tsd": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.7.2",
   "description": "A low overhead rate limiter for your routes",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -1,12 +1,29 @@
+import fastify, {
+  FastifyInstance,
+  FastifyRequest,
+  preHandlerAsyncHookHandler,
+  RequestGenericInterface,
+  RouteOptions
+} from 'fastify'
 import * as http2 from 'http2'
-import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface, FastifyReply, preHandlerAsyncHookHandler } from 'fastify';
-import * as ioredis from 'ioredis';
-import fastifyRateLimit, { FastifyRateLimitStore, FastifyRateLimitOptions, errorResponseBuilderContext, RateLimitPluginOptions } from '../../';
+import { default as ioredis } from 'ioredis'
+import fastifyRateLimit, {
+  errorResponseBuilderContext,
+  FastifyRateLimitOptions,
+  FastifyRateLimitStore,
+  RateLimitPluginOptions
+} from '../..'
 
 class CustomStore implements FastifyRateLimitStore {
   constructor(options: FastifyRateLimitOptions) {}
-  incr(key: string, callback: ( error: Error|null, result?: { current: number, ttl: number } ) => void) {}
-  child(routeOptions: RouteOptions & { path: string, prefix: string }) {
+  incr(
+    key: string,
+    callback: (
+      error: Error | null,
+      result?: { current: number; ttl: number }
+    ) => void
+  ) {}
+  child(routeOptions: RouteOptions & { path: string; prefix: string }) {
     return <CustomStore>(<FastifyRateLimitOptions>{})
   }
 }
@@ -23,7 +40,10 @@ const options1: RateLimitPluginOptions = {
   ban: 10,
   continueExceeding: false,
   keyGenerator: (req: FastifyRequest<RequestGenericInterface>) => req.ip,
-  errorResponseBuilder: (req: FastifyRequest<RequestGenericInterface>, context: errorResponseBuilderContext) => ({ code: 429, timeWindow: context.after, limit: context.max }),
+  errorResponseBuilder: (
+    req: FastifyRequest<RequestGenericInterface>,
+    context: errorResponseBuilderContext
+  ) => ({ code: 429, timeWindow: context.after, limit: context.max }),
   addHeadersOnExceeding: {
     'x-ratelimit-limit': false,
     'x-ratelimit-remaining': false,
@@ -39,14 +59,14 @@ const options1: RateLimitPluginOptions = {
 
 const options2 = {
   global: true,
-  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => (42),
-  allowList: (req: FastifyRequest<RequestGenericInterface>, key: string) => (false),
+  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => 42,
+  allowList: (req: FastifyRequest<RequestGenericInterface>, key: string) => false,
   timeWindow: 5000
 }
 
 const options3 = {
   global: true,
-  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => (42),
+  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => 42,
   timeWindow: 5000,
   store: CustomStore
 }
@@ -62,11 +82,11 @@ appWithImplicitHttp.register(fastifyRateLimit, options1)
 appWithImplicitHttp.register(fastifyRateLimit, options2)
 
 appWithImplicitHttp.register(fastifyRateLimit, options3).then(() => {
-  const preHandler1:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit()
-  const preHandler2:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options1)
-  const preHandler3:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options2)
-  const preHandler4:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options3)
-  const preHandler5:preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options4);
+  const preHandler1: preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit()
+  const preHandler2: preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options1)
+  const preHandler3: preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options2)
+  const preHandler4: preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options3)
+  const preHandler5: preHandlerAsyncHookHandler = appWithImplicitHttp.rateLimit(options4)
   // The following test is dependent on https://github.com/fastify/fastify/pull/2929
   // appWithImplicitHttp.setNotFoundHandler({
   //   preHandler: appWithImplicitHttp.rateLimit()
@@ -74,7 +94,6 @@ appWithImplicitHttp.register(fastifyRateLimit, options3).then(() => {
   //   reply.status(404).send(new Error('Not found'))
   // })
 })
-
 
 const appWithHttp2: FastifyInstance<
   http2.Http2Server,


### PR DESCRIPTION
Hello.

This PR aims to:
- upgrade package dependencies
- update typescript definitions
- fix typescript tests by using `import { default as ioredis } from 'ioredis'` syntax to import ioredis (following https://github.com/fastify/fastify-rate-limit/pull/198 CI typescript test failure)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
