### PR TITLE
fix: added onExceeding and onExceeded to be available

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ You can pass a Redis client here and magically the issue is solved. To achieve t
 - `addHeadersOnExceeding`: define which headers should be added in the response when the limit is not reached. Defaults all the headers will be shown
 - `addHeaders`: define which headers should be added in the response when the limit is reached. Defaults all the headers will be shown
 - `enableDraftSpec`: if `true` it will change the HTTP rate limit headers following the IEFT draft document. More information at [draft-ietf-httpapi-ratelimit-headers.md](https://github.com/ietf-wg-httpapi/ratelimit-headers/blob/f6a7bc7560a776ea96d800cf5ed3752d6d397b06/draft-ietf-httpapi-ratelimit-headers.md).
+- `onExceeding`: callback that will be executed before request limit has been reached. 
+- `onExceeded`: callback that will be executed after request limit has been reached. 
 
 `keyGenerator` example usage:
 ```js
@@ -249,6 +251,25 @@ The `routeOptions` object passed to the `child` method of the store will contain
 
 - `routeInfo`: The configuration of the route including `method`, `url`, `path`, and the full route `config`
 
+Custom `onExceeding` example usage:
+```js
+await fastify.register(import('@fastify/rate-limit'), {
+  /* */
+  onExceeding: function (req) {
+    console.log('callback on exceeding ... executed before response to client')
+  }
+})
+```
+
+Custom `onExceeded` example usage:
+```js
+await fastify.register(import('@fastify/rate-limit'), {
+  /* */
+  onExceeded: function (req) {
+    console.log('callback on exceeded ... executed before response to client')
+  }
+})
+```
 ### Options on the endpoint itself
 
 Rate limiting can be also can be configured at the route level, applying the configuration independently.

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,8 @@ export interface RateLimitOptions {
     context: errorResponseBuilderContext
   ) => object;
   enableDraftSpec?: boolean;
+  onExceeding?: (req: FastifyRequest) => void;
+  onExceeded?: (req: FastifyRequest) => void;
 }
 
 export interface RateLimitPluginOptions extends RateLimitOptions {

--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ async function rateLimitPlugin (fastify, settings) {
   globalParams.errorResponseBuilder = defaultErrorResponse
   globalParams.isCustomErrorMessage = false
 
+  globalParams.onExceeded = settings.onExceeded
+  globalParams.onExceeding = settings.onExceeding
+
   // define if error message was overwritten with a custom error response callback
   if (typeof settings.errorResponseBuilder === 'function') {
     globalParams.errorResponseBuilder = settings.errorResponseBuilder

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -240,6 +240,56 @@ test('With function allowList', async t => {
   t.equal(res.statusCode, 429)
 })
 
+test('With onExceeding option', async t => {
+  t.plan(5)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    max: 2,
+    timeWindow: '2s',
+    onExceeding: function (req) {
+      t.pass('onExceeding called')
+    }
+  })
+
+  fastify.get('/', async (req, reply) => 'hello!')
+
+  let res
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+})
+
+test('With onExceeded option', async t => {
+  t.plan(5)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    max: 2,
+    timeWindow: '2s',
+    onExceeded: function (req) {
+      t.pass('onExceeded called')
+    }
+  })
+
+  fastify.get('/', async (req, reply) => 'hello!')
+
+  let res
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+})
+
 test('With redis store', async t => {
   t.plan(19)
   const fastify = Fastify()

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -266,7 +266,7 @@ test('With onExceeding option', async t => {
 })
 
 test('With onExceeded option', async t => {
-  t.plan(5)
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -199,6 +199,64 @@ test('With function allowList', async t => {
   t.equal(res.statusCode, 429)
 })
 
+test('With onExceeding option', async t => {
+  t.plan(5)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, { global: false })
+
+  fastify.get('/', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: '2s',
+        onExceeding: function (req) {
+          t.pass('onExceeding called')
+        }
+      }
+    }
+  }, async (req, res) => 'hello!')
+
+  let res
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+})
+
+test('With onExceeded option', async t => {
+  t.plan(4)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, { global: false })
+
+  fastify.get('/', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: '2s',
+        onExceeded: function (req) {
+          t.pass('onExceeded called')
+        }
+      }
+    }
+  }, async (req, res) => 'hello!')
+
+  let res
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+})
+
 test('With redis store', async t => {
   t.plan(19)
   const fastify = Fastify()

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -54,7 +54,9 @@ const options1: RateLimitPluginOptions = {
     'x-ratelimit-remaining': false,
     'x-ratelimit-reset': false,
     'retry-after': false
-  }
+  },
+  onExceeding: (req: FastifyRequest<RequestGenericInterface>) => ({}),
+  onExceeded: (req: FastifyRequest<RequestGenericInterface>) => ({}) 
 }
 const options2: RateLimitPluginOptions = {
   global: true,


### PR DESCRIPTION
onExceeding and onExceeded to be available
issue #232 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
