### PR TITLE
test: fix flaky redis unit tests

### DIFF
--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -332,13 +332,13 @@ test('With redis store', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 1)
-  t.equal(res.headers['x-ratelimit-reset'], 1)
+  t.ok(res.headers['x-ratelimit-reset'] < 2)
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 0)
-  t.equal(res.headers['x-ratelimit-reset'], 0)
+  t.ok(res.headers['x-ratelimit-reset'] < 2)
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 429)
@@ -389,20 +389,18 @@ test('Skip on redis error', async t => {
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 
+  await redis.flushall()
+  await redis.quit()
+
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.equal(res.headers['x-ratelimit-remaining'], 2)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 0)
-
-  t.teardown(async () => {
-    await redis.flushall()
-    await redis.quit()
-  })
+  t.equal(res.headers['x-ratelimit-remaining'], 2)
 })
 
 test('With keyGenerator', async t => {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -1114,14 +1114,14 @@ test('When use a custom nameSpace', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 0)
-  t.equal(res.headers['x-ratelimit-reset'], 0)
+  t.ok(res.headers['x-ratelimit-reset'] < 2)
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 0)
-  t.equal(res.headers['x-ratelimit-reset'], 0)
+  t.ok(res.headers['x-ratelimit-reset'] < 2)
   t.equal(res.headers['retry-after'], 1000)
   t.same({
     statusCode: 429,

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -337,20 +337,18 @@ test('Skip on redis error', async t => {
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 
+  await redis.flushall()
+  await redis.quit()
+
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 0)
+  t.equal(res.headers['x-ratelimit-remaining'], 2)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 0)
-
-  t.teardown(async () => {
-    await redis.flushall()
-    await redis.quit()
-  })
+  t.equal(res.headers['x-ratelimit-remaining'], 2)
 })
 
 test('With keyGenerator', async t => {

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -8,7 +8,6 @@ const rateLimit = require('../index')
 const FakeTimers = require('@sinonjs/fake-timers')
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
-const noop = () => { }
 
 const REDIS_HOST = '127.0.0.1'
 
@@ -301,12 +300,15 @@ test('With redis store', async t => {
   await sleep(1100)
 
   res = await fastify.inject('/')
-  redis.flushall(noop)
-  redis.quit(noop)
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 1)
   t.equal(res.headers['x-ratelimit-reset'], 1)
+
+  t.teardown(async () => {
+    await redis.flushall()
+    await redis.quit()
+  })
 })
 
 test('Skip on redis error', async t => {
@@ -335,18 +337,20 @@ test('Skip on redis error', async t => {
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 1)
 
-  redis.flushall(noop)
-  await redis.quit()
-
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.equal(res.statusCode, 429)
   t.equal(res.headers['x-ratelimit-limit'], 2)
-  t.equal(res.headers['x-ratelimit-remaining'], 2)
+  t.equal(res.headers['x-ratelimit-remaining'], 0)
+
+  t.teardown(async () => {
+    await redis.flushall()
+    await redis.quit()
+  })
 })
 
 test('With keyGenerator', async t => {
@@ -1291,9 +1295,9 @@ test('When continue exceeding is on (Redis)', async t => {
   t.equal(second.headers['x-ratelimit-remaining'], 0)
   t.equal(second.headers['x-ratelimit-reset'], 5)
 
-  t.teardown(() => {
-    redis.flushall(noop)
-    redis.quit(noop)
+  t.teardown(async () => {
+    await redis.flushall()
+    await redis.quit()
   })
 })
 


### PR DESCRIPTION
We were running the unit tests in a very flaky way. Instead of actually waiting the redis flushall command we were having a noop callback. So it could happen, that flushall was not done and we were already running the next test.

This PR fixes that by implementing a teardown for those redis tests and fixing the corresponding assertions. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
