### PR TITLE
tests: head routes get applied rate limiting hook only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,12 +128,6 @@ async function rateLimitPlugin (fastify, settings) {
 
   // onRoute add the hook rate-limit function if needed
   fastify.addHook('onRoute', (routeOptions) => {
-    if (
-      routeOptions.method === 'HEAD' &&
-      routeOptions.exposeHeadRoute === true
-    ) {
-      return
-    }
     if (routeOptions.config && typeof routeOptions.config.rateLimit !== 'undefined') {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const current = Object.create(pluginComponent)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fastify/pre-commit": "^2.0.2",
     "@sinonjs/fake-timers": "^9.1.0",
     "@types/node": "^18.0.0",
-    "fastify": "^4.0.0-rc.2",
+    "fastify": "fastify/fastify#fix-reuse-route-option",
     "ioredis": "^5.0.5",
     "knex": "^2.0.0",
     "sqlite3": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fastify/pre-commit": "^2.0.2",
     "@sinonjs/fake-timers": "^9.1.0",
     "@types/node": "^18.0.0",
-    "fastify": "fastify/fastify#fix-reuse-route-option",
+    "fastify": "^4.7.0",
     "ioredis": "^5.0.5",
     "knex": "^2.0.0",
     "sqlite3": "^5.0.2",

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -281,7 +281,7 @@ test('With redis store', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], 2)
   t.equal(res.headers['x-ratelimit-remaining'], 0)
-  t.equal(res.headers['x-ratelimit-reset'], 0)
+  t.ok(res.headers['x-ratelimit-reset'] < 2)
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 429)
@@ -1148,7 +1148,7 @@ test('per route rate limit', async t => {
 
   t.equal(resHead.statusCode, 200, 'HEAD: Response status code')
   t.equal(resHead.headers['x-ratelimit-limit'], 10, 'HEAD: x-ratelimit-limit header (per route limit)')
-  t.equal(resHead.headers['x-ratelimit-remaining'], 8, 'HEAD: x-ratelimit-remaining header (per route limit)')
+  t.equal(resHead.headers['x-ratelimit-remaining'], 9, 'HEAD: x-ratelimit-remaining header (per route limit)')
 })
 
 test('Allow custom timeWindow in preHandler', async t => {
@@ -1406,15 +1406,14 @@ test('on rateLimitHook should not be set twice on HEAD', async t => {
     }
   }, async (req, reply) => 'fastify is awesome !')
 
-  // would fail
-  // fastify.head('/explicit-head-2', {
-  //   exposeHeadRoute: true,
-  //   config: {
-  //     rateLimit: {
-  //       max: 1,
-  //       timeWindow: 10000,
-  //       hook: 'onRequest'
-  //     }
-  //   }
-  // }, async (req, reply) => 'fastify is awesome !')
+  fastify.head('/explicit-head-2', {
+    exposeHeadRoute: true,
+    config: {
+      rateLimit: {
+        max: 1,
+        timeWindow: 10000,
+        hook: 'onRequest'
+      }
+    }
+  }, async (req, reply) => 'fastify is awesome !')
 })


### PR DESCRIPTION
There was a bug in fastify core, where an onRoute hook would be called twice on automatic generated HEAD routes. This was fixed in core. This PR fixes unit tests and adds one regarding the expected behaviour.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
