### PR TITLE
Don't set the reply code automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ You can change the response by providing a callback to `errorResponseBuilder` or
 
 ```js
 fastify.setErrorHandler(function (error, request, reply) {
-  if (reply.statusCode === 429) {
+  if (error.statusCode === 429) {
+    reply.code(429)
     error.message = 'You hit the rate limit! Slow down please!'
   }
   reply.send(error)

--- a/index.js
+++ b/index.js
@@ -263,11 +263,11 @@ function rateLimitRequestHandler (params, pluginComponent) {
       params.onBanReach(req, key)
     }
 
-    throw params.errorResponseBuilder(respCtx)
+    throw params.errorResponseBuilder(req, respCtx)
   }
 }
 
-function defaultErrorResponse (context) {
+function defaultErrorResponse (req, context) {
   const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
   err.statusCode = context.statusCode
   return err

--- a/index.js
+++ b/index.js
@@ -251,8 +251,6 @@ function rateLimitRequestHandler (params, pluginComponent) {
     }
 
     const code = params.ban && current - maximum > params.ban ? 403 : 429
-    res.code(code)
-
     const respCtx = {
       statusCode: code,
       after,
@@ -264,11 +262,12 @@ function rateLimitRequestHandler (params, pluginComponent) {
       respCtx.ban = true
       params.onBanReach(req, key)
     }
-    return res.send(params.errorResponseBuilder(req, respCtx))
+
+    throw params.errorResponseBuilder(respCtx)
   }
 }
 
-function defaultErrorResponse (req, context) {
+function defaultErrorResponse (context) {
   const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
   err.statusCode = context.statusCode
   return err

--- a/test/github-issues/issue-284.test.js
+++ b/test/github-issues/issue-284.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const FakeTimers = require('@sinonjs/fake-timers')
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const rateLimit = require('../../index')
+
+t.beforeEach(t => {
+  t.context.clock = FakeTimers.install()
+})
+
+t.afterEach(t => {
+  t.context.clock.uninstall()
+})
+
+test('issue #207 - when continueExceeding is true and the store is local then it should reset the rate-limit', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(rateLimit, {
+    global: false
+  })
+
+  fastify.setErrorHandler((err, req, res) => {
+    res.redirect("/")
+  })
+
+  fastify.get('/', {
+    config: {
+      rateLimit: {
+        max: 1,
+        timeWindow: 5000,
+        continueExceeding: true
+      }
+    }
+  }, async () => {
+    return 'hello!'
+  })
+
+  const firstOkResponse = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+  const firstRateLimitResponse = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  // After this the rate limiter should allow for new requests
+  t.context.clock.tick(5000)
+
+  const okResponseAfterRateLimitCompleted = await fastify.inject({
+    url: '/',
+    method: 'GET'
+  })
+
+  t.equal(firstOkResponse.statusCode, 200)
+
+  t.equal(firstRateLimitResponse.statusCode, 302)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-limit'], 1)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-remaining'], 0)
+  t.equal(firstRateLimitResponse.headers['x-ratelimit-reset'], 5)
+
+  t.equal(okResponseAfterRateLimitCompleted.statusCode, 200)
+})

--- a/test/github-issues/issue-284.test.js
+++ b/test/github-issues/issue-284.test.js
@@ -22,7 +22,10 @@ test('issue #207 - when continueExceeding is true and the store is local then it
   })
 
   fastify.setErrorHandler((err, req, res) => {
-    res.redirect("/")
+    t.equal(res.statusCode, 200)
+    t.equal(err.statusCode, 429)
+
+    res.redirect('/')
   })
 
   fastify.get('/', {

--- a/test/github-issues/issue-284.test.js
+++ b/test/github-issues/issue-284.test.js
@@ -14,7 +14,7 @@ t.afterEach(t => {
   t.context.clock.uninstall()
 })
 
-test('issue #207 - when continueExceeding is true and the store is local then it should reset the rate-limit', async t => {
+test("issue #284 - don't set the reply code automatically", async t => {
   const fastify = Fastify()
 
   await fastify.register(rateLimit, {

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -599,7 +599,7 @@ test('custom error response', async t => {
   await fastify.register(rateLimit, {
     global: false,
     errorResponseBuilder: (req, context) => ({
-      code: 429,
+      statusCode: 429,
       timeWindow: context.after,
       limit: context.max
     })
@@ -633,7 +633,7 @@ test('custom error response', async t => {
   t.equal(res.headers['x-ratelimit-remaining'], 0)
   t.equal(res.headers['retry-after'], 1000)
   t.same(JSON.parse(res.payload), {
-    code: 429,
+    statusCode: 429,
     timeWindow: '1 second',
     limit: 2
   })

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -33,7 +33,8 @@ test('Basic', async t => {
 
   fastify.setErrorHandler(function (error, request, reply) {
     t.pass('Error handler has been called')
-    t.equal(reply.statusCode, 429)
+    t.equal(error.statusCode, 429)
+    reply.code(429)
     error.message += ' from error handler'
     reply.send(error)
   })


### PR DESCRIPTION
Closes #284

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] documentation is changed or added
