### PR TITLE
chore: remove defaultOnBanReach helper fn

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,8 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.allowList = settings.allowList || settings.whitelist || null
   globalParams.ban = settings.ban || null
   globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : undefined
+  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : undefined
+  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : undefined
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
   // define the name of the app component. Related to redis, it will be use as a part of the keyname define in redis.
@@ -90,9 +92,6 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
     ? settings.keyGenerator
     : (req) => req.ip
-
-  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : undefined
-  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : undefined
 
   // define if error message was overwritten with a custom error response callback
   if (typeof settings.errorResponseBuilder === 'function') {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ async function fastifyRateLimit (fastify, settings) {
   if (typeof settings.enableDraftSpec === 'boolean' && settings.enableDraftSpec) {
     globalParams.enableDraftSpec = true
     labels = draftSpecHeaders
+  } else {
+    globalParams.enableDraftSpec = false
   }
 
   globalParams.addHeaders = Object.assign({
@@ -66,12 +68,7 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
   globalParams.ban = settings.ban || null
-  globalParams.onBanReach = defaultOnBanReach
-
-  if (typeof settings.onBanReach === 'function') {
-    globalParams.onBanReach = settings.onBanReach
-  }
-
+  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : undefined
   globalParams.continueExceeding = settings.continueExceeding || false
 
   // define the name of the app component. Related to redis, it will be use as a part of the keyname define in redis.
@@ -94,9 +91,6 @@ async function fastifyRateLimit (fastify, settings) {
     ? settings.keyGenerator
     : (req) => req.ip
 
-  globalParams.errorResponseBuilder = defaultErrorResponse
-  globalParams.isCustomErrorMessage = false
-
   globalParams.onExceeded = settings.onExceeded
   globalParams.onExceeding = settings.onExceeding
 
@@ -104,13 +98,17 @@ async function fastifyRateLimit (fastify, settings) {
   if (typeof settings.errorResponseBuilder === 'function') {
     globalParams.errorResponseBuilder = settings.errorResponseBuilder
     globalParams.isCustomErrorMessage = true
+  } else {
+    globalParams.errorResponseBuilder = defaultErrorResponse
+    globalParams.isCustomErrorMessage = false
   }
 
-  globalParams.skipOnError = settings.skipOnError || false
+  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
 
   const run = Symbol('rate-limit-did-run')
   pluginComponent.run = run
   fastify.decorateRequest(run, false)
+
   if (!fastify.hasDecorator('rateLimit')) {
     // The rate limit plugin can be registered multiple times but decorate throws if called multiple times for the same field
     fastify.decorate('rateLimit', function rateLimit (options) {
@@ -265,7 +263,7 @@ function rateLimitRequestHandler (params, pluginComponent) {
 
     if (code === 403) {
       respCtx.ban = true
-      params.onBanReach(req, key)
+      if (typeof params.onBanReach === 'function') params.onBanReach(req, key)
     }
 
     throw params.errorResponseBuilder(req, respCtx)
@@ -277,8 +275,6 @@ function defaultErrorResponse (req, context) {
   err.statusCode = context.statusCode
   return err
 }
-
-function defaultOnBanReach (req, key) {}
 
 module.exports = fp(fastifyRateLimit, {
   fastify: '4.x',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
All custom function parameters, like `onExceeded` and `onExceeding`, only get run if they're defined. However, `onBan` has a default function that is just empty (old, line 281, 268)

Under stress from an IP, that function can get called thousands of times, which probably still wouldn't cause a problem (🤣), but why run it in the first place?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
