### PR TITLE
use toad-cache, fix bugs, simplify the code

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,15 +105,15 @@ async function fastifyRateLimit (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     fastify.decorate('rateLimit', (options) => {
-      const params = options ? mergeParams(globalParams, options) : globalParams
 
-      if (params.timeWindow && params.timeWindow !== globalParams.timeWindow) {
+      if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        newPluginComponent.store = newPluginComponent.store.child(Object.assign({}, params))
-        return rateLimitRequestHandler(newPluginComponent, params)
+        const mergedRateLimitParams = mergeParams(globalParams, options)
+        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+        return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
-      return rateLimitRequestHandler(pluginComponent, params)
+      return rateLimitRequestHandler(pluginComponent, globalParams)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -158,6 +158,7 @@ function addRouteRateHook (pluginComponent, globalParams, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
+  const store = pluginComponent.store
   return async function onRequestRateLimiter (req, res) {
     const rateLimitRan = pluginComponent.rateLimitRan
 
@@ -189,7 +190,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     // We increment the rate limit for the current request
     try {
       const res = await new Promise(function (resolve, reject) {
-        pluginComponent.store.incr(key, (err, res) => {
+        store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -188,15 +188,11 @@ function rateLimitRequestHandler (pluginComponent, params) {
     try {
       const res = await new Promise((resolve, reject) => {
         store.incr(key, (err, res) => {
-          if (err) {
-            reject(err)
-            return
-          }
-          resolve(res)
+          err ? reject(err) : resolve(res)
         }, max)
       })
 
-      current = res.current
+      current = res.count
       ttl = res.ttl
     } catch (err) {
       if (!params.skipOnError) {

--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
   globalParams.ban = settings.ban || null
-  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : undefined
-  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : undefined
-  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : undefined
+  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : null
+  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : null
+  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : null
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ async function fastifyRateLimit (fastify, settings) {
     : typeof settings.timeWindow === 'number' && !isNaN(settings.timeWindow)
       ? settings.timeWindow
       : 1000 * 60
-  globalParams.timeWindowInSeconds = (globalParams.timeWindow / 1000) | 0
+  globalParams.timeWindowInSeconds = Math.floor(globalParams.timeWindow / 1000)
 
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
@@ -140,7 +140,7 @@ function mergeParams (params1, params2) {
     result.timeWindow = ms.parse(result.timeWindow)
   }
   if (typeof result.timeWindow === 'number' && !isNaN(result.timeWindow)) {
-    result.timeWindowInSeconds = (result.timeWindow / 1000) | 0
+    result.timeWindowInSeconds = Math.floor(result.timeWindow / 1000)
   }
   return result
 }

--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ async function fastifyRateLimit (fastify, settings) {
 
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
+    rateLimitRan,
     allowList: globalParams.allowList,
-    store: null,
-    rateLimitRan
+    store: null
   }
 
   if (settings.store) {
@@ -159,13 +159,11 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 
 function rateLimitRequestHandler (pluginComponent, params) {
   return async function onRequestRateLimiter (req, res) {
-    const rateLimitRan = pluginComponent.rateLimitRan
-
-    if (req[rateLimitRan]) {
+    if (req[pluginComponent.rateLimitRan]) {
       return
     }
 
-    req[rateLimitRan] = true
+    req[pluginComponent.rateLimitRan] = true
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     const key = await params.keyGenerator(req)

--- a/index.js
+++ b/index.js
@@ -69,6 +69,20 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : noop
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
+  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
+    ? settings.keyGenerator
+    : defaultKeyGenerator
+
+  if (typeof settings.errorResponseBuilder === 'function') {
+    globalParams.errorResponseBuilder = settings.errorResponseBuilder
+    globalParams.isCustomErrorMessage = true
+  } else {
+    globalParams.errorResponseBuilder = defaultErrorResponse
+    globalParams.isCustomErrorMessage = false
+  }
+
+  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
+
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
     rateLimitRan,
@@ -85,20 +99,6 @@ async function fastifyRateLimit (fastify, settings) {
       pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, settings.continueExceeding)
     }
   }
-
-  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
-    ? settings.keyGenerator
-    : defaultKeyGenerator
-
-  if (typeof settings.errorResponseBuilder === 'function') {
-    globalParams.errorResponseBuilder = settings.errorResponseBuilder
-    globalParams.isCustomErrorMessage = true
-  } else {
-    globalParams.errorResponseBuilder = defaultErrorResponse
-    globalParams.isCustomErrorMessage = false
-  }
-
-  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
 
   fastify.decorateRequest(rateLimitRan, false)
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ async function fastifyRateLimit (fastify, settings) {
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, options)
-        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+        newPluginComponent.store = newPluginComponent.store.child(Object.assign({ routeInfo: {} }, mergedRateLimitParams))
         return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
@@ -121,7 +121,7 @@ async function fastifyRateLimit (fastify, settings) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit)
-        newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
+        newPluginComponent.store = pluginComponent.store.child(Object.assign({ routeInfo: routeOptions }, mergedRateLimitParams))
         addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')

--- a/index.js
+++ b/index.js
@@ -158,7 +158,6 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
-  const store = pluginComponent.store
   return async function onRequestRateLimiter (req, res) {
     const rateLimitRan = pluginComponent.rateLimitRan
 
@@ -190,7 +189,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     // We increment the rate limit for the current request
     try {
       const res = await new Promise(function (resolve, reject) {
-        store.incr(key, (err, res) => {
+        pluginComponent.store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -145,9 +145,9 @@ function mergeParams (params1, params2) {
   return result
 }
 
-function addRouteRateHook (pluginComponent, globalParams, routeOptions) {
-  const hook = globalParams.hook || defaultHook
-  const hookHandler = rateLimitRequestHandler(pluginComponent, globalParams)
+function addRouteRateHook (pluginComponent, params, routeOptions) {
+  const hook = params.hook || defaultHook
+  const hookHandler = rateLimitRequestHandler(pluginComponent, params)
   if (Array.isArray(routeOptions[hook])) {
     routeOptions[hook].push(hookHandler)
   } else if (typeof routeOptions[hook] === 'function') {

--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ async function fastifyRateLimit (fastify, settings) {
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
     rateLimitRan,
-    allowList: globalParams.allowList,
     store: null
   }
 

--- a/index.js
+++ b/index.js
@@ -158,19 +158,21 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
+  const { rateLimitRan, store } = pluginComponent
+
   return async function onRequestRateLimiter (req, res) {
-    if (req[pluginComponent.rateLimitRan]) {
+    if (req[rateLimitRan]) {
       return
     }
 
-    req[pluginComponent.rateLimitRan] = true
+    req[rateLimitRan] = true
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     const key = await params.keyGenerator(req)
 
     // Don't apply any rate limiting if in the allow list
     if (params.allowList) {
-      if (typeof pluginComponent.allowList === 'function') {
+      if (typeof params.allowList === 'function') {
         if (await params.allowList(req, key)) {
           return
         }
@@ -186,8 +188,8 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     // We increment the rate limit for the current request
     try {
-      const res = await new Promise(function (resolve, reject) {
-        pluginComponent.store.incr(key, (err, res) => {
+      const res = await new Promise((resolve, reject) => {
+        store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ async function fastifyRateLimit (fastify, settings) {
     fastify.decorate('rateLimit', (options) => {
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        const mergedRateLimitParams = mergeParams(globalParams, options)
-        newPluginComponent.store = newPluginComponent.store.child(Object.assign({ routeInfo: {} }, mergedRateLimitParams))
+        const mergedRateLimitParams = mergeParams(globalParams, options, { routeInfo: {} })
+        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
         return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
@@ -120,8 +120,8 @@ async function fastifyRateLimit (fastify, settings) {
     if (routeOptions.config?.rateLimit !== undefined) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit)
-        newPluginComponent.store = pluginComponent.store.child(Object.assign({ routeInfo: routeOptions }, mergedRateLimitParams))
+        const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
+        newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
         addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')
@@ -133,8 +133,8 @@ async function fastifyRateLimit (fastify, settings) {
   })
 }
 
-function mergeParams (params1, params2) {
-  const result = Object.assign({}, params1, params2)
+function mergeParams (...params) {
+  const result = Object.assign({}, ...params)
   if (typeof result.timeWindow === 'string') {
     result.timeWindow = ms.parse(result.timeWindow)
   }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ async function fastifyRateLimit (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     fastify.decorate('rateLimit', (options) => {
-
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, options)

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
         }, max)
       })
 
-      current = res.count
+      current = res.current
       ttl = res.ttl
     } catch (err) {
       if (!params.skipOnError) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@lukeed/ms": "^2.0.1",
     "fastify-plugin": "^4.0.0",
-    "tiny-lru": "^11.0.0"
+    "toad-cache": "^3.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -21,6 +21,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     if (current.count > max) {
       current.iterationStartMs = nowInMs
     }
+
     this.lru.set(ip, current)
     cb(null, { current: current.count, ttl: this.timeWindow })
   } else {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -13,13 +13,13 @@ LocalStore.prototype.incr = function (ip, cb, max) {
 
   let current = this.lru.get(ip)
   if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
-    current = { count: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
+    current = { current: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
   }
 
-  ++current.count
+  ++current.current
 
   if (this.continueExceeding) {
-    if (current.count > max) {
+    if (current.current > max) {
       current.iterationStartMs = nowInMs
     }
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -13,7 +13,9 @@ LocalStore.prototype.incr = function (ip, cb, max) {
 
   let current = this.lru.get(ip)
 
-  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) current = { count: 0, iterationStartMs: nowInMs }
+  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
+    current = { count: 0, iterationStartMs: nowInMs }
+  }
 
   ++current.count
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,8 +12,12 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
 
   let current = this.lru.get(ip)
-  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
+  if (current === undefined) {
     current = { current: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
+  } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
+    current.current = 0
+    current.iterationStartMs = nowInMs
+    current.ttl = this.timeWindow
   }
 
   ++current.current

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,9 +12,8 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
 
   let current = this.lru.get(ip)
-
   if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
-    current = { count: 0, iterationStartMs: nowInMs }
+    current = { count: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
   }
 
   ++current.count
@@ -25,10 +24,11 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     }
 
     this.lru.set(ip, current)
-    cb(null, { current: current.count, ttl: this.timeWindow })
+    cb(null, current)
   } else {
     this.lru.set(ip, current)
-    cb(null, { current: current.count, ttl: this.timeWindow - (nowInMs - current.iterationStartMs) })
+    current.ttl = this.timeWindow - (nowInMs - current.iterationStartMs)
+    cb(null, current)
   }
 }
 

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -16,9 +16,9 @@ RedisStore.prototype.incr = function (ip, cb) {
       .incr(key)
       .pexpire(key, this.timeWindow)
       .exec((err, result) => {
-        if (err) return cb(err, { count: 0 })
-        if (result[0][0]) return cb(result[0][0], { count: 0 })
-        cb(null, { count: result[0][1], ttl: this.timeWindow })
+        if (err) return cb(err, { current: 0 })
+        if (result[0][0]) return cb(result[0][0], { current: 0 })
+        cb(null, { current: result[0][1], ttl: this.timeWindow })
       })
   } else {
     this.redis.pipeline()
@@ -29,13 +29,13 @@ RedisStore.prototype.incr = function (ip, cb) {
          * result[0] => incr response: [0]: error, [1]: new incr value
          * result[1] => pttl response: [0]: error, [1]: ttl remaining
          */
-        if (err) return cb(err, { count: 0 })
-        if (result[0][0]) return cb(result[0][0], { count: 0 })
+        if (err) return cb(err, { current: 0 })
+        if (result[0][0]) return cb(result[0][0], { current: 0 })
         if (result[1][1] === -1) {
           this.redis.pexpire(key, this.timeWindow, noop)
           result[1][1] = this.timeWindow
         }
-        cb(null, { count: result[0][1], ttl: result[1][1] })
+        cb(null, { current: result[0][1], ttl: result[1][1] })
       })
   }
 }

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -16,9 +16,9 @@ RedisStore.prototype.incr = function (ip, cb) {
       .incr(key)
       .pexpire(key, this.timeWindow)
       .exec((err, result) => {
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
-        cb(null, { current: result[0][1], ttl: this.timeWindow })
+        if (err) return cb(err, { count: 0 })
+        if (result[0][0]) return cb(result[0][0], { count: 0 })
+        cb(null, { count: result[0][1], ttl: this.timeWindow })
       })
   } else {
     this.redis.pipeline()
@@ -29,13 +29,13 @@ RedisStore.prototype.incr = function (ip, cb) {
          * result[0] => incr response: [0]: error, [1]: new incr value
          * result[1] => pttl response: [0]: error, [1]: ttl remaining
          */
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
+        if (err) return cb(err, { count: 0 })
+        if (result[0][0]) return cb(result[0][0], { count: 0 })
         if (result[1][1] === -1) {
           this.redis.pexpire(key, this.timeWindow, noop)
           result[1][1] = this.timeWindow
         }
-        cb(null, { current: result[0][1], ttl: result[1][1] })
+        cb(null, { count: result[0][1], ttl: result[1][1] })
       })
   }
 }

--- a/test/not-found-handler-rate-limited.test.js
+++ b/test/not-found-handler-rate-limited.test.js
@@ -82,13 +82,13 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 429)
@@ -96,7 +96,7 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
   t.equal(res.headers['retry-after'], '2')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1379,6 +1379,31 @@ test("child's allowList should override parent's function", async t => {
   t.equal(res.statusCode, 200)
 })
 
+test("fastify.rateLimit should work when a property other than timeWindow is modified", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    onRequest: fastify.rateLimit({
+      allowList: ['127.0.0.1'], max: 2
+    })
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
 test('on preValidation hook', async t => {
   const fastify = Fastify()
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1356,6 +1356,29 @@ test('should consider routes allow list', async t => {
   t.equal(res.statusCode, 200)
 })
 
+test("child's allowList should override parent's function", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
 test('on preValidation hook', async t => {
   const fastify = Fastify()
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1379,7 +1379,7 @@ test("child's allowList should override parent's function", async t => {
   t.equal(res.statusCode, 200)
 })
 
-test("fastify.rateLimit should work when a property other than timeWindow is modified", async t => {
+test('fastify.rateLimit should work when a property other than timeWindow is modified', async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     global: false,


### PR DESCRIPTION
Rate limiting is a crucial part of a web application, so we must constantly strive to improve `fastify-rate-limit`'s performance and architecture

Before doing some more significant improvements, I wanted to simplify the codebase so that future changes don't get mixed up with these

This PR results in some performance gain thanks to the following changes:

### use `toad-cache`
Toad cache is faster than `tiny-lru` in [important](https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-get-inmemory/_results/results.md) [benchmarks](https://github.com/kibertoad/nodejs-benchmark-tournament/blob/master/cache-set-inmemory/_results/results.md) and I've shared my interest with kibertoad on how we can centralize all LRU and FIFO packages to his within Fastify

### use our own TTL
I realized while looking at the source code that we already store an `iterationStartTime` using `Date.now()`, we are however not doing enough with this information and just returning it back to user. We can increase performance by disabling the TTL in the LRU (since it would otherwise have more `Date.now` calls) and reseting a request lazily ourselves

### move objects and functions out of the main function
Since `rate-limit` supports being registered multiple times, every time a user does that, we are risking recreating the objects that are inside the main function, which can lead to increased memory usage

### change logic order
In places like the onRequest handler, we would do calculations before checking for conditions that would get us out of the logic flow, for instance we would parse the timeWindow string using `ms` before checking if the hook had already run

### bug fixes
- A flaky test (that would occasionally fail on `master` as well) was fixed
- The route config's `allowList` would get ignored if the global `allowList` property was a function
- when the decorated rateLimit function was used with an option object that didn't have the `timeWindow` property, ex: `fastify.rateLimit({max: 5})`, the options would not get registered

I've added tests for the bug fixes

Benchmark (new vs. old, highest of 5 runs):
```shell
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.04 ms │ 10 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 48991   │ 48991   │ 50591   │ 66495   │ 54250.19 │ 6412.41 │ 48982   │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 17.9 MB │ 17.9 MB │ 18.9 MB │ 19.9 MB │ 18.9 MB  │ 517 kB  │ 17.8 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

150000 2xx responses, 446750 non 2xx responses
597k requests in 11.01s, 208 MB read
```

```shell
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬──────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max  │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼──────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.04 ms │ 7 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴──────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 47871   │ 47871   │ 49983   │ 66111   │ 53460.37 │ 6605.44 │ 47843   │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 17.7 MB │ 17.7 MB │ 18.7 MB │ 19.7 MB │ 18.6 MB  │ 542 kB  │ 17.7 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

150000 2xx responses, 438058 non 2xx responses
588k requests in 11.01s, 205 MB read
```