### PR TITLE
fix RedisStore resetting the TTL unnecessarily and align its behavior with LocalStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,15 +105,15 @@ async function fastifyRateLimit (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     fastify.decorate('rateLimit', (options) => {
-      const params = options ? mergeParams(globalParams, options) : globalParams
 
-      if (params.timeWindow && params.timeWindow !== globalParams.timeWindow) {
+      if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        newPluginComponent.store = newPluginComponent.store.child(Object.assign({}, params))
-        return rateLimitRequestHandler(newPluginComponent, params)
+        const mergedRateLimitParams = mergeParams(globalParams, options)
+        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+        return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
-      return rateLimitRequestHandler(pluginComponent, params)
+      return rateLimitRequestHandler(pluginComponent, globalParams)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -158,6 +158,7 @@ function addRouteRateHook (pluginComponent, globalParams, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
+  const store = pluginComponent.store
   return async function onRequestRateLimiter (req, res) {
     const rateLimitRan = pluginComponent.rateLimitRan
 
@@ -189,7 +190,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     // We increment the rate limit for the current request
     try {
       const res = await new Promise(function (resolve, reject) {
-        pluginComponent.store.incr(key, (err, res) => {
+        store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -188,15 +188,11 @@ function rateLimitRequestHandler (pluginComponent, params) {
     try {
       const res = await new Promise((resolve, reject) => {
         store.incr(key, (err, res) => {
-          if (err) {
-            reject(err)
-            return
-          }
-          resolve(res)
+          err ? reject(err) : resolve(res)
         }, max)
       })
 
-      current = res.current
+      current = res.count
       ttl = res.ttl
     } catch (err) {
       if (!params.skipOnError) {

--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
   globalParams.ban = settings.ban || null
-  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : undefined
-  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : undefined
-  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : undefined
+  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : null
+  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : null
+  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : null
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ async function fastifyRateLimit (fastify, settings) {
     : typeof settings.timeWindow === 'number' && !isNaN(settings.timeWindow)
       ? settings.timeWindow
       : 1000 * 60
-  globalParams.timeWindowInSeconds = (globalParams.timeWindow / 1000) | 0
+  globalParams.timeWindowInSeconds = Math.floor(globalParams.timeWindow / 1000)
 
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
@@ -140,7 +140,7 @@ function mergeParams (params1, params2) {
     result.timeWindow = ms.parse(result.timeWindow)
   }
   if (typeof result.timeWindow === 'number' && !isNaN(result.timeWindow)) {
-    result.timeWindowInSeconds = (result.timeWindow / 1000) | 0
+    result.timeWindowInSeconds = Math.floor(result.timeWindow / 1000)
   }
   return result
 }

--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ async function fastifyRateLimit (fastify, settings) {
 
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
+    rateLimitRan,
     allowList: globalParams.allowList,
-    store: null,
-    rateLimitRan
+    store: null
   }
 
   if (settings.store) {
@@ -159,13 +159,11 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 
 function rateLimitRequestHandler (pluginComponent, params) {
   return async function onRequestRateLimiter (req, res) {
-    const rateLimitRan = pluginComponent.rateLimitRan
-
-    if (req[rateLimitRan]) {
+    if (req[pluginComponent.rateLimitRan]) {
       return
     }
 
-    req[rateLimitRan] = true
+    req[pluginComponent.rateLimitRan] = true
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     const key = await params.keyGenerator(req)

--- a/index.js
+++ b/index.js
@@ -69,6 +69,20 @@ async function fastifyRateLimit (fastify, settings) {
   globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : noop
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
+  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
+    ? settings.keyGenerator
+    : defaultKeyGenerator
+
+  if (typeof settings.errorResponseBuilder === 'function') {
+    globalParams.errorResponseBuilder = settings.errorResponseBuilder
+    globalParams.isCustomErrorMessage = true
+  } else {
+    globalParams.errorResponseBuilder = defaultErrorResponse
+    globalParams.isCustomErrorMessage = false
+  }
+
+  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
+
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
     rateLimitRan,
@@ -85,20 +99,6 @@ async function fastifyRateLimit (fastify, settings) {
       pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, settings.continueExceeding)
     }
   }
-
-  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
-    ? settings.keyGenerator
-    : defaultKeyGenerator
-
-  if (typeof settings.errorResponseBuilder === 'function') {
-    globalParams.errorResponseBuilder = settings.errorResponseBuilder
-    globalParams.isCustomErrorMessage = true
-  } else {
-    globalParams.errorResponseBuilder = defaultErrorResponse
-    globalParams.isCustomErrorMessage = false
-  }
-
-  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
 
   fastify.decorateRequest(rateLimitRan, false)
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ async function fastifyRateLimit (fastify, settings) {
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, options)
-        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+        newPluginComponent.store = newPluginComponent.store.child(Object.assign({ routeInfo: {} }, mergedRateLimitParams))
         return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
@@ -121,7 +121,7 @@ async function fastifyRateLimit (fastify, settings) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit)
-        newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
+        newPluginComponent.store = pluginComponent.store.child(Object.assign({ routeInfo: routeOptions }, mergedRateLimitParams))
         addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')

--- a/index.js
+++ b/index.js
@@ -158,7 +158,6 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
-  const store = pluginComponent.store
   return async function onRequestRateLimiter (req, res) {
     const rateLimitRan = pluginComponent.rateLimitRan
 
@@ -190,7 +189,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     // We increment the rate limit for the current request
     try {
       const res = await new Promise(function (resolve, reject) {
-        store.incr(key, (err, res) => {
+        pluginComponent.store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -145,9 +145,9 @@ function mergeParams (params1, params2) {
   return result
 }
 
-function addRouteRateHook (pluginComponent, globalParams, routeOptions) {
-  const hook = globalParams.hook || defaultHook
-  const hookHandler = rateLimitRequestHandler(pluginComponent, globalParams)
+function addRouteRateHook (pluginComponent, params, routeOptions) {
+  const hook = params.hook || defaultHook
+  const hookHandler = rateLimitRequestHandler(pluginComponent, params)
   if (Array.isArray(routeOptions[hook])) {
     routeOptions[hook].push(hookHandler)
   } else if (typeof routeOptions[hook] === 'function') {

--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ async function fastifyRateLimit (fastify, settings) {
   const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
     rateLimitRan,
-    allowList: globalParams.allowList,
     store: null
   }
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ async function fastifyRateLimit (fastify, settings) {
     pluginComponent.store = new Store(globalParams)
   } else {
     if (settings.redis) {
-      pluginComponent.store = new RedisStore(settings.redis, settings.nameSpace || 'fastify-rate-limit-', globalParams.timeWindow, settings.continueExceeding)
+      pluginComponent.store = new RedisStore(settings.redis, globalParams.timeWindow, settings.continueExceeding, settings.nameSpace || 'fastify-rate-limit-')
     } else {
       pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, settings.continueExceeding)
     }
@@ -158,7 +158,7 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 function rateLimitRequestHandler (pluginComponent, params) {
   const { rateLimitRan, store } = pluginComponent
 
-  return async function onRequestRateLimiter (req, res) {
+  return async (req, res) => {
     if (req[rateLimitRan]) {
       return
     }
@@ -229,7 +229,6 @@ function rateLimitRequestHandler (pluginComponent, params) {
       max,
       ttl,
       after: ms.format(params.timeWindow, true)
-
     }
 
     if (code === 403) {

--- a/index.js
+++ b/index.js
@@ -158,19 +158,21 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 }
 
 function rateLimitRequestHandler (pluginComponent, params) {
+  const { rateLimitRan, store } = pluginComponent
+
   return async function onRequestRateLimiter (req, res) {
-    if (req[pluginComponent.rateLimitRan]) {
+    if (req[rateLimitRan]) {
       return
     }
 
-    req[pluginComponent.rateLimitRan] = true
+    req[rateLimitRan] = true
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     const key = await params.keyGenerator(req)
 
     // Don't apply any rate limiting if in the allow list
     if (params.allowList) {
-      if (typeof pluginComponent.allowList === 'function') {
+      if (typeof params.allowList === 'function') {
         if (await params.allowList(req, key)) {
           return
         }
@@ -186,8 +188,8 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     // We increment the rate limit for the current request
     try {
-      const res = await new Promise(function (resolve, reject) {
-        pluginComponent.store.incr(key, (err, res) => {
+      const res = await new Promise((resolve, reject) => {
+        store.incr(key, (err, res) => {
           if (err) {
             reject(err)
             return

--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ async function fastifyRateLimit (fastify, settings) {
     fastify.decorate('rateLimit', (options) => {
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        const mergedRateLimitParams = mergeParams(globalParams, options)
-        newPluginComponent.store = newPluginComponent.store.child(Object.assign({ routeInfo: {} }, mergedRateLimitParams))
+        const mergedRateLimitParams = mergeParams(globalParams, options, { routeInfo: {} })
+        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
         return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
 
@@ -120,8 +120,8 @@ async function fastifyRateLimit (fastify, settings) {
     if (routeOptions.config?.rateLimit !== undefined) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit)
-        newPluginComponent.store = pluginComponent.store.child(Object.assign({ routeInfo: routeOptions }, mergedRateLimitParams))
+        const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
+        newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
         addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')
@@ -133,8 +133,8 @@ async function fastifyRateLimit (fastify, settings) {
   })
 }
 
-function mergeParams (params1, params2) {
-  const result = Object.assign({}, params1, params2)
+function mergeParams (...params) {
+  const result = Object.assign({}, ...params)
   if (typeof result.timeWindow === 'string') {
     result.timeWindow = ms.parse(result.timeWindow)
   }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ async function fastifyRateLimit (fastify, settings) {
 
   if (!fastify.hasDecorator('rateLimit')) {
     fastify.decorate('rateLimit', (options) => {
-
       if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, options)

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
         }, max)
       })
 
-      current = res.count
+      current = res.current
       ttl = res.ttl
     } catch (err) {
       if (!params.skipOnError) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@lukeed/ms": "^2.0.1",
     "fastify-plugin": "^4.0.0",
-    "tiny-lru": "^11.0.0"
+    "toad-cache": "^3.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -17,7 +17,6 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
     current.current = 0
     current.iterationStartMs = nowInMs
-    current.ttl = this.timeWindow
   }
 
   ++current.current

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -21,6 +21,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     if (current.count > max) {
       current.iterationStartMs = nowInMs
     }
+
     this.lru.set(ip, current)
     cb(null, { current: current.count, ttl: this.timeWindow })
   } else {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,7 +12,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
   let current = this.lru.get(ip)
 
-  if (current === undefined) {
+  if (!current) {
     // Item doesn't exist
     current = { current: 1, iterationStartMs: nowInMs, ttl: this.timeWindow }
   } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -13,13 +13,13 @@ LocalStore.prototype.incr = function (ip, cb, max) {
 
   let current = this.lru.get(ip)
   if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
-    current = { count: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
+    current = { current: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
   }
 
-  ++current.count
+  ++current.current
 
   if (this.continueExceeding) {
-    if (current.count > max) {
+    if (current.current > max) {
       current.iterationStartMs = nowInMs
     }
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -13,7 +13,9 @@ LocalStore.prototype.incr = function (ip, cb, max) {
 
   let current = this.lru.get(ip)
 
-  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) current = { count: 0, iterationStartMs: nowInMs }
+  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
+    current = { count: 0, iterationStartMs: nowInMs }
+  }
 
   ++current.count
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -22,18 +22,15 @@ LocalStore.prototype.incr = function (ip, cb, max) {
 
   ++current.current
 
-  if (this.continueExceeding) {
-    if (current.current > max) {
-      current.iterationStartMs = nowInMs
-    }
-
-    this.lru.set(ip, current)
-    cb(null, current)
+  if (this.continueExceeding && current.current > max) {
+    current.iterationStartMs = nowInMs
+    current.ttl = this.timeWindow
   } else {
-    this.lru.set(ip, current)
     current.ttl = this.timeWindow - (nowInMs - current.iterationStartMs)
-    cb(null, current)
   }
+
+  this.lru.set(ip, current)
+  cb(null, current)
 }
 
 LocalStore.prototype.child = function (routeOptions) {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,8 +12,12 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
 
   let current = this.lru.get(ip)
-  if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
+  if (current === undefined) {
     current = { current: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
+  } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
+    current.current = 0
+    current.iterationStartMs = nowInMs
+    current.ttl = this.timeWindow
   }
 
   ++current.current

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,9 +12,8 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
 
   let current = this.lru.get(ip)
-
   if (current === undefined || (current.iterationStartMs + this.timeWindow <= nowInMs)) {
-    current = { count: 0, iterationStartMs: nowInMs }
+    current = { count: 0, iterationStartMs: nowInMs, ttl: this.timeWindow }
   }
 
   ++current.count
@@ -25,10 +24,11 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     }
 
     this.lru.set(ip, current)
-    cb(null, { current: current.count, ttl: this.timeWindow })
+    cb(null, current)
   } else {
     this.lru.set(ip, current)
-    cb(null, { current: current.count, ttl: this.timeWindow - (nowInMs - current.iterationStartMs) })
+    current.ttl = this.timeWindow - (nowInMs - current.iterationStartMs)
+    cb(null, current)
   }
 }
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -16,7 +16,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     // Item doesn't exist
     current = { current: 1, iterationStartMs: nowInMs, ttl: this.timeWindow }
   } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
-    // Item's TTL has expired
+    // Item has expired
     current.current = 1
     current.iterationStartMs = nowInMs
     current.ttl = this.timeWindow

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -1,51 +1,48 @@
 'use strict'
 
-const noop = () => { }
-
-function RedisStore (redis, key, timeWindow, continueExceeding) {
+function RedisStore (redis, timeWindow, continueExceeding, key) {
   this.redis = redis
   this.timeWindow = timeWindow
-  this.key = key
   this.continueExceeding = continueExceeding
+  this.key = key
 }
 
-RedisStore.prototype.incr = function (ip, cb) {
+RedisStore.prototype.incr = function (ip, cb, max) {
   const key = this.key + ip
-  if (this.continueExceeding) {
-    this.redis.pipeline()
-      .incr(key)
-      .pexpire(key, this.timeWindow)
-      .exec((err, result) => {
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
+
+  this.redis.pipeline()
+    .incr(key)
+    .pttl(key)
+    .exec((err, result) => {
+    /**
+     * result[0] => incr response: [0]: error, [1]: new incr value
+     * result[1] => pttl response: [0]: error, [1]: ttl remaining
+     */
+      if (err || result[0][0] || result[1][0]) {
+        cb(err || result[0][0] || result[1][0], { current: 1, ttl: this.timeWindow })
+        return
+      }
+
+      if (result[1][1] === -1) {
+        this.redis.pexpire(key, this.timeWindow, noop)
+        cb(null, { current: 1, ttl: this.timeWindow })
+        return
+      }
+
+      if (this.continueExceeding && result[0][1] > max) {
+        this.redis.pexpire(key, this.timeWindow, noop)
         cb(null, { current: result[0][1], ttl: this.timeWindow })
-      })
-  } else {
-    this.redis.pipeline()
-      .incr(key)
-      .pttl(key)
-      .exec((err, result) => {
-        /**
-         * result[0] => incr response: [0]: error, [1]: new incr value
-         * result[1] => pttl response: [0]: error, [1]: ttl remaining
-         */
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
-        if (result[1][1] === -1) {
-          this.redis.pexpire(key, this.timeWindow, noop)
-          result[1][1] = this.timeWindow
-        }
-        cb(null, { current: result[0][1], ttl: result[1][1] })
-      })
-  }
+        return
+      }
+
+      cb(null, { current: result[0][1], ttl: result[1][1] })
+    })
 }
 
 RedisStore.prototype.child = function (routeOptions) {
-  const child = Object.create(this)
-  child.key = this.key + routeOptions.routeInfo.method + routeOptions.routeInfo.url + '-'
-  child.timeWindow = routeOptions.timeWindow
-  child.continueExceeding = routeOptions.continueExceeding
-  return child
+  return new RedisStore(this.redis, routeOptions.timeWindow, routeOptions.continueExceeding, this.key + routeOptions.routeInfo.method + routeOptions.routeInfo.url + '-')
 }
+
+function noop () {}
 
 module.exports = RedisStore

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -24,7 +24,7 @@ RedisStore.prototype.incr = function (ip, cb, max) {
       }
 
       if (result[1][1] === -1) {
-        // Item's TTL has expired or it just got created
+        // Item just got created
         this.redis.pexpire(key, this.timeWindow, noop)
         cb(null, { current: 1, ttl: this.timeWindow })
         return

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -16,9 +16,9 @@ RedisStore.prototype.incr = function (ip, cb) {
       .incr(key)
       .pexpire(key, this.timeWindow)
       .exec((err, result) => {
-        if (err) return cb(err, { count: 0 })
-        if (result[0][0]) return cb(result[0][0], { count: 0 })
-        cb(null, { count: result[0][1], ttl: this.timeWindow })
+        if (err) return cb(err, { current: 0 })
+        if (result[0][0]) return cb(result[0][0], { current: 0 })
+        cb(null, { current: result[0][1], ttl: this.timeWindow })
       })
   } else {
     this.redis.pipeline()
@@ -29,13 +29,13 @@ RedisStore.prototype.incr = function (ip, cb) {
          * result[0] => incr response: [0]: error, [1]: new incr value
          * result[1] => pttl response: [0]: error, [1]: ttl remaining
          */
-        if (err) return cb(err, { count: 0 })
-        if (result[0][0]) return cb(result[0][0], { count: 0 })
+        if (err) return cb(err, { current: 0 })
+        if (result[0][0]) return cb(result[0][0], { current: 0 })
         if (result[1][1] === -1) {
           this.redis.pexpire(key, this.timeWindow, noop)
           result[1][1] = this.timeWindow
         }
-        cb(null, { count: result[0][1], ttl: result[1][1] })
+        cb(null, { current: result[0][1], ttl: result[1][1] })
       })
   }
 }

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -16,9 +16,9 @@ RedisStore.prototype.incr = function (ip, cb) {
       .incr(key)
       .pexpire(key, this.timeWindow)
       .exec((err, result) => {
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
-        cb(null, { current: result[0][1], ttl: this.timeWindow })
+        if (err) return cb(err, { count: 0 })
+        if (result[0][0]) return cb(result[0][0], { count: 0 })
+        cb(null, { count: result[0][1], ttl: this.timeWindow })
       })
   } else {
     this.redis.pipeline()
@@ -29,13 +29,13 @@ RedisStore.prototype.incr = function (ip, cb) {
          * result[0] => incr response: [0]: error, [1]: new incr value
          * result[1] => pttl response: [0]: error, [1]: ttl remaining
          */
-        if (err) return cb(err, { current: 0 })
-        if (result[0][0]) return cb(result[0][0], { current: 0 })
+        if (err) return cb(err, { count: 0 })
+        if (result[0][0]) return cb(result[0][0], { count: 0 })
         if (result[1][1] === -1) {
           this.redis.pexpire(key, this.timeWindow, noop)
           result[1][1] = this.timeWindow
         }
-        cb(null, { current: result[0][1], ttl: result[1][1] })
+        cb(null, { count: result[0][1], ttl: result[1][1] })
       })
   }
 }

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -24,12 +24,14 @@ RedisStore.prototype.incr = function (ip, cb, max) {
       }
 
       if (result[1][1] === -1) {
+        // Item's TTL has expired or it just got created
         this.redis.pexpire(key, this.timeWindow, noop)
         cb(null, { current: 1, ttl: this.timeWindow })
         return
       }
 
       if (this.continueExceeding && result[0][1] > max) {
+        // Reset TLL if max has been exceeded and `continueExceeding` is enabled
         this.redis.pexpire(key, this.timeWindow, noop)
         cb(null, { current: result[0][1], ttl: this.timeWindow })
         return

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -439,6 +439,62 @@ test('With redis store', async t => {
   })
 })
 
+test('Redis with continueExceeding should not always return the timeWindow', async t => {
+  t.plan(19)
+  const fastify = Fastify()
+  const redis = new Redis({ host: REDIS_HOST })
+  await fastify.register(rateLimit, {
+    max: 2,
+    timeWindow: 3000,
+    continueExceeding: true,
+    redis
+  })
+
+  fastify.get('/', async (req, reply) => 'hello!')
+
+  let res
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], '2')
+  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.ok(['0', '1', '2', '3'].includes(res.headers['x-ratelimit-reset']))
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['x-ratelimit-limit'], '2')
+  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.ok(['0', '1', '2', '3'].includes(res.headers['x-ratelimit-reset']))
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 429)
+  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  t.equal(res.headers['x-ratelimit-limit'], '2')
+  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.equal(res.headers['x-ratelimit-reset'], '3')
+  t.equal(res.headers['retry-after'], '3')
+  t.same({
+    statusCode: 429,
+    error: 'Too Many Requests',
+    message: 'Rate limit exceeded, retry in 3 seconds'
+  }, JSON.parse(res.payload))
+
+  // Not using fake timers here as we use an external Redis that would not be effected by this
+  await sleep(1000)
+
+  res = await fastify.inject('/')
+
+  t.equal(res.statusCode, 429)
+  t.equal(res.headers['x-ratelimit-limit'], '2')
+  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.equal(res.headers['x-ratelimit-reset'], '3')
+
+  t.teardown(async () => {
+    await redis.flushall()
+    await redis.quit()
+  })
+})
+
 test('Skip on redis error', async t => {
   t.plan(9)
   const fastify = Fastify()

--- a/test/not-found-handler-rate-limited.test.js
+++ b/test/not-found-handler-rate-limited.test.js
@@ -82,13 +82,13 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 429)
@@ -96,7 +96,7 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
   t.equal(res.headers['retry-after'], '2')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1379,6 +1379,31 @@ test("child's allowList should override parent's function", async t => {
   t.equal(res.statusCode, 200)
 })
 
+test("fastify.rateLimit should work when a property other than timeWindow is modified", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    onRequest: fastify.rateLimit({
+      allowList: ['127.0.0.1'], max: 2
+    })
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
 test('on preValidation hook', async t => {
   const fastify = Fastify()
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1356,6 +1356,29 @@ test('should consider routes allow list', async t => {
   t.equal(res.statusCode, 200)
 })
 
+test("child's allowList should override parent's function", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
 test('on preValidation hook', async t => {
   const fastify = Fastify()
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1379,7 +1379,7 @@ test("child's allowList should override parent's function", async t => {
   t.equal(res.statusCode, 200)
 })
 
-test("fastify.rateLimit should work when a property other than timeWindow is modified", async t => {
+test('fastify.rateLimit should work when a property other than timeWindow is modified', async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     global: false,


### PR DESCRIPTION
Fixes #304 and closes #321

Motivation: **the implementations of the LocalStore and the RedisStore are doing different things**, which is inconsistent and confusing users.

For instance, when `continueExceeding` is `true`, RedisStore *always* resets the TTL of an IP, even when it hasn't yet exceeded the limit. This causes people get rate limited more than necessary because for every request that hasn't exceeded the max, we keep on resetting the ttl instead of letting it go down, while also incrementing the counter.

This PR makes RedisStore mirror LocalStore's behavior. We increment the counter but do not reset the TLL unless the limit is exceeded, after which the TTL is reset for every request as long as the key is alive.

This should land after #320

**If you only want to see the changes of this PR, you can see my local PR: https://github.com/gurgunday/fastify-rate-limit/pull/2**

I still don't know how to create a PR on another PR 🤠