### PR TITLE
Retry-After: return the TTL instead of timeWindow

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,10 +245,7 @@ function rateLimitRequestHandler (params, pluginComponent) {
     if (params.addHeaders[params.labels.rateLimit]) { res.header(params.labels.rateLimit, maximum) }
     if (params.addHeaders[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, 0) }
     if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeft) }
-    if (params.addHeaders[params.labels.retryAfter]) {
-      const resetAfterTime = (params.enableDraftSpec ? timeLeft : params.timeWindowInSeconds)
-      res.header(params.labels.retryAfter, resetAfterTime)
-    }
+    if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeft) }
 
     const code = params.ban && current - maximum > params.ban ? 403 : 429
     const respCtx = {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -415,8 +415,8 @@ test('With redis store', async t => {
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '0')
-  t.equal(res.headers['retry-after'], '1')
+  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
+  t.ok(['0', '1'].includes(res.headers['retry-after']))
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
@@ -594,7 +594,8 @@ test('With async/await keyGenerator', async t => {
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '1')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
+  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
+  t.ok(['0', '1'].includes(res.headers['retry-after']))
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
@@ -660,7 +661,7 @@ test('With CustomStore', async t => {
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
   t.equal(res.headers['x-ratelimit-reset'], '7')
-  t.equal(res.headers['retry-after'], '10')
+  t.equal(res.headers['retry-after'], '7')
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
@@ -1276,7 +1277,7 @@ test('When use a custom nameSpace', async t => {
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
   t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
-  t.equal(res.headers['retry-after'], '1')
+  t.ok(['0', '1'].includes(res.headers['retry-after']))
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/not-found-handler-rate-limited.test.js
+++ b/test/not-found-handler-rate-limited.test.js
@@ -38,8 +38,8 @@ test('Set not found handler can be rate limited', async t => {
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
   t.equal(res.headers['x-ratelimit-reset'], '0')
+  t.equal(res.headers['retry-after'], '0')
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',
@@ -82,21 +82,21 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '2')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.equal(res.headers['retry-after'], '1')
+  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1358,31 +1358,6 @@ test('should consider routes allow list', async t => {
   t.equal(res.statusCode, 200)
 })
 
-test('fastify.rateLimit should work when a property other than timeWindow is modified', async t => {
-  const fastify = Fastify()
-  await fastify.register(rateLimit, {
-    global: false,
-    allowList: (req, key) => false
-  })
-
-  fastify.get('/', {
-    onRequest: fastify.rateLimit({
-      allowList: ['127.0.0.1'], max: 2
-    })
-  }, (req, reply) => {
-    reply.send('hello!')
-  })
-
-  let res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-})
-
 test('on preValidation hook', async t => {
   const fastify = Fastify()
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1358,29 +1358,6 @@ test('should consider routes allow list', async t => {
   t.equal(res.statusCode, 200)
 })
 
-test("child's allowList should override parent's function", async t => {
-  const fastify = Fastify()
-  await fastify.register(rateLimit, {
-    global: false,
-    allowList: (req, key) => false
-  })
-
-  fastify.get('/', {
-    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
-  }, (req, reply) => {
-    reply.send('hello!')
-  })
-
-  let res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-})
-
 test('fastify.rateLimit should work when a property other than timeWindow is modified', async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {


### PR DESCRIPTION
`Retry-After`, the internet standard counterpart of `x-ratelimit-reset`, was for some reason always being set to the `timeWindow` property when rate limiting took place - so for instance even when a user had to wait for 5 more seconds for rate limiting to be lifted (with a timeWindow of 15 seconds), the user would still see on the header the number 15 instead of 5

[I traced back a change](https://github.com/fastify/fastify-rate-limit/commit/6de4257297e7bb23d6fc4d0e1eeefa36d3b987a5#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R188) that, while introducing the optional draft headers feature, had done away with this but probably couldn't change the default behavior to make it non-breaking

[While another breaking PR is up](https://github.com/fastify/fastify-rate-limit/pull/323), I think we can also make this change