### PR TITLE
Use `Math.ceil` for timeLeft calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ function rateLimitRequestHandler (params, pluginComponent) {
       }
     }
 
-    const timeLeft = Math.floor(ttl / 1000)
+    const timeLeft = Math.ceil(ttl / 1000)
 
     if (current <= maximum) {
       if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, maximum) }

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -402,21 +402,23 @@ test('With redis store', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '1')
+
+  await sleep(100)
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
-  t.ok(['0', '1'].includes(res.headers['retry-after']))
+  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.equal(res.headers['retry-after'], '1')
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
@@ -594,8 +596,8 @@ test('With async/await keyGenerator', async t => {
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '1')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
-  t.ok(['0', '1'].includes(res.headers['retry-after']))
+  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.equal(res.headers['retry-after'], '1')
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
@@ -1110,10 +1112,10 @@ test('afterReset and Rate Limit remain the same when enableDraftSpec is enabled'
   t.equal(res.headers['ratelimit-remaining'], '0')
 
   t.context.clock.tick(500)
-  await retry('9')
+  await retry('10')
 
   t.context.clock.tick(1000)
-  await retry('8')
+  await retry('9')
 
   async function retry (timeLeft) {
     const res = await fastify.inject('/')
@@ -1269,15 +1271,15 @@ test('When use a custom nameSpace', async t => {
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(res.headers['x-ratelimit-reset'] < 2)
+  t.equal(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject(allowListHeader)
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1'].includes(res.headers['x-ratelimit-reset']))
-  t.ok(['0', '1'].includes(res.headers['retry-after']))
+  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.equal(res.headers['retry-after'], '1')
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/not-found-handler-rate-limited.test.js
+++ b/test/not-found-handler-rate-limited.test.js
@@ -31,15 +31,15 @@ test('Set not found handler can be rate limited', async t => {
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '0')
+  t.equal(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '0')
-  t.equal(res.headers['retry-after'], '0')
+  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.equal(res.headers['retry-after'], '1')
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',
@@ -76,27 +76,27 @@ test('Set not found handler can be rate limited with specific options', async t 
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '2')
-  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 404)
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
   t.equal(res.statusCode, 429)
   t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
   t.equal(res.headers['x-ratelimit-limit'], '4')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['retry-after'], '2')
+  t.equal(res.headers['x-ratelimit-reset'], '2')
   t.same(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1298,7 +1298,6 @@ test('When continue exceeding is on (Local)', async t => {
   t.equal(second.headers['x-ratelimit-reset'], '5')
 })
 
-
 test('When continue exceeding is on (Redis)', async t => {
   const fastify = Fastify()
   const redis = await new Redis({ host: REDIS_HOST })


### PR DESCRIPTION
Last (small) breaking change, promise 😁

Here's the case for it: it changes nothing on our side, but sending an endpoint `Retry-After: 0` is arguably worse than sending `Retry-After: 1` when they still have 900ms of blockage

Also, the whole idea of sending `Retry-After: 0` makes no sense

And finally, all tests that contained checks against multiple values have been modified