### PR TITLE
Refactor `index.js` to fix multiple bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ const draftSpecHeaders = {
   retryAfter: 'retry-after'
 }
 
+const defaultKeyGenerator = (req) => req.ip
+
+const defaultErrorResponse = (req, context) => {
+  const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
+  err.statusCode = context.statusCode
+  return err
+}
+
 async function fastifyRateLimit (fastify, settings) {
   const globalParams = {
     global: (typeof settings.global === 'boolean') ? settings.global : true
@@ -235,14 +243,6 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     throw params.errorResponseBuilder(req, respCtx)
   }
-}
-
-function defaultKeyGenerator (req) { return req.ip }
-
-function defaultErrorResponse (req, context) {
-  const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
-  err.statusCode = context.statusCode
-  return err
 }
 
 module.exports = fp(fastifyRateLimit, {

--- a/index.js
+++ b/index.js
@@ -8,74 +8,85 @@ const RedisStore = require('./store/RedisStore')
 
 const defaultHook = 'onRequest'
 
+const defaultHeaders = {
+  rateLimit: 'x-ratelimit-limit',
+  rateRemaining: 'x-ratelimit-remaining',
+  rateReset: 'x-ratelimit-reset',
+  retryAfter: 'retry-after'
+}
+
+const draftSpecHeaders = {
+  rateLimit: 'ratelimit-limit',
+  rateRemaining: 'ratelimit-remaining',
+  rateReset: 'ratelimit-reset',
+  retryAfter: 'retry-after'
+}
+
 async function fastifyRateLimit (fastify, settings) {
-  let labels = {
-    rateLimit: 'x-ratelimit-limit',
-    rateRemaining: 'x-ratelimit-remaining',
-    rateReset: 'x-ratelimit-reset',
-    retryAfter: 'retry-after'
-  }
-
-  const draftSpecHeaders = {
-    rateLimit: 'ratelimit-limit',
-    rateRemaining: 'ratelimit-remaining',
-    rateReset: 'ratelimit-reset',
-    retryAfter: 'retry-after'
-  }
-
-  // create the object that will hold the "main" settings that can be shared during the build
-  // 'global' will define, if the rate limit should be apply by default on all route. default : true
   const globalParams = {
     global: (typeof settings.global === 'boolean') ? settings.global : true
   }
 
   if (typeof settings.enableDraftSpec === 'boolean' && settings.enableDraftSpec) {
     globalParams.enableDraftSpec = true
-    labels = draftSpecHeaders
+    globalParams.labels = draftSpecHeaders
   } else {
     globalParams.enableDraftSpec = false
+    globalParams.labels = defaultHeaders
   }
 
   globalParams.addHeaders = Object.assign({
-    [labels.rateLimit]: true,
-    [labels.rateRemaining]: true,
-    [labels.rateReset]: true,
-    [labels.retryAfter]: true
+    [globalParams.labels.rateLimit]: true,
+    [globalParams.labels.rateRemaining]: true,
+    [globalParams.labels.rateReset]: true,
+    [globalParams.labels.retryAfter]: true
   }, settings.addHeaders)
 
   globalParams.addHeadersOnExceeding = Object.assign({
-    [labels.rateLimit]: true,
-    [labels.rateRemaining]: true,
-    [labels.rateReset]: true
+    [globalParams.labels.rateLimit]: true,
+    [globalParams.labels.rateRemaining]: true,
+    [globalParams.labels.rateReset]: true
   }, settings.addHeadersOnExceeding)
 
-  globalParams.labels = labels
-
-  // define the global maximum of request allowed
+  // Global maximum allowed requests
   globalParams.max = ((typeof settings.max === 'number' && !isNaN(settings.max)) || typeof settings.max === 'function')
     ? settings.max
     : 1000
 
-  // define the global Time Window
+  // Global time window
   globalParams.timeWindow = typeof settings.timeWindow === 'string'
     ? ms.parse(settings.timeWindow)
     : typeof settings.timeWindow === 'number' && !isNaN(settings.timeWindow)
       ? settings.timeWindow
       : 1000 * 60
-
-  globalParams.timeWindowInSeconds = (globalParams.timeWindow / 1000) | 0
+  globalParams.timeWindowInSeconds = Math.floor(globalParams.timeWindow / 1000)
 
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
-  globalParams.ban = settings.ban || null
-  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : undefined
-  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : undefined
-  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : undefined
+  globalParams.ban = settings.ban || 0 // 0 means turned off
+  globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : null
+  globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : null
+  globalParams.onExceeded = typeof settings.onExceeded === 'function' ? settings.onExceeded : null
   globalParams.continueExceeding = typeof settings.continueExceeding === 'boolean' ? settings.continueExceeding : false
 
-  // define the name of the app component. Related to redis, it will be use as a part of the keyname define in redis.
+  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
+    ? settings.keyGenerator
+    : defaultKeyGenerator
+
+  if (typeof settings.errorResponseBuilder === 'function') {
+    globalParams.errorResponseBuilder = settings.errorResponseBuilder
+    globalParams.isCustomErrorMessage = true
+  } else {
+    globalParams.errorResponseBuilder = defaultErrorResponse
+    globalParams.isCustomErrorMessage = false
+  }
+
+  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
+
+  const rateLimitRan = Symbol('fastify.request.rateLimitRan')
   const pluginComponent = {
-    allowList: globalParams.allowList
+    rateLimitRan,
+    store: null
   }
 
   if (settings.store) {
@@ -89,80 +100,52 @@ async function fastifyRateLimit (fastify, settings) {
     }
   }
 
-  globalParams.keyGenerator = typeof settings.keyGenerator === 'function'
-    ? settings.keyGenerator
-    : (req) => req.ip
-
-  // define if error message was overwritten with a custom error response callback
-  if (typeof settings.errorResponseBuilder === 'function') {
-    globalParams.errorResponseBuilder = settings.errorResponseBuilder
-    globalParams.isCustomErrorMessage = true
-  } else {
-    globalParams.errorResponseBuilder = defaultErrorResponse
-    globalParams.isCustomErrorMessage = false
-  }
-
-  globalParams.skipOnError = typeof settings.skipOnError === 'boolean' ? settings.skipOnError : false
-
-  const run = Symbol('rate-limit-did-run')
-  pluginComponent.run = run
-  fastify.decorateRequest(run, false)
+  fastify.decorateRequest(rateLimitRan, false)
 
   if (!fastify.hasDecorator('rateLimit')) {
-    // The rate limit plugin can be registered multiple times but decorate throws if called multiple times for the same field
-    fastify.decorate('rateLimit', function rateLimit (options) {
-      let params = globalParams
-      if (options) {
-        params = makeParams(options)
-      }
-      if (params.timeWindow && params.timeWindow !== globalParams.timeWindow) {
+    fastify.decorate('rateLimit', (options) => {
+      if (typeof options === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
-        const newStore = newPluginComponent.store.child(Object.assign({}, { routeInfo: {} }, params))
-        newPluginComponent.store = newStore
-        return rateLimitRequestHandler(params, newPluginComponent)
+        const mergedRateLimitParams = mergeParams(globalParams, options, { routeInfo: {} })
+        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+        return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
       }
-      return rateLimitRequestHandler(params, pluginComponent)
+
+      return rateLimitRequestHandler(pluginComponent, globalParams)
     })
   }
 
-  // onRoute add the hook rate-limit function if needed
   fastify.addHook('onRoute', (routeOptions) => {
-    if (routeOptions.config && typeof routeOptions.config.rateLimit !== 'undefined') {
+    if (routeOptions.config?.rateLimit !== undefined) {
       if (typeof routeOptions.config.rateLimit === 'object') {
-        const current = Object.create(pluginComponent)
-        const mergedRateLimitParams = makeParams(routeOptions.config.rateLimit)
-        mergedRateLimitParams.routeInfo = routeOptions
-        current.store = pluginComponent.store.child(mergedRateLimitParams)
-        // if the current endpoint have a custom rateLimit configuration ...
-        addRouteRateHook(current, mergedRateLimitParams, routeOptions)
-      } else if (routeOptions.config.rateLimit === false) {
-        // don't apply any rate-limit
-      } else {
+        const newPluginComponent = Object.create(pluginComponent)
+        const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
+        newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
+        addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
+      } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')
       }
     } else if (globalParams.global) {
-      // if the plugin is set globally ( meaning that all the route will be 'rate limited' )
-      // As the endpoint, does not have a custom rateLimit configuration, use the global one.
+      // As the endpoint does not have a custom configuration, use the global one
       addRouteRateHook(pluginComponent, globalParams, routeOptions)
     }
   })
-
-  // Merge the parameters of a route with the global ones
-  function makeParams (routeParams) {
-    const result = Object.assign({}, globalParams, routeParams)
-    if (typeof result.timeWindow === 'string') {
-      result.timeWindow = ms.parse(result.timeWindow)
-    }
-    if (typeof result.timeWindow === 'number') {
-      result.timeWindowInSeconds = (result.timeWindow / 1000) | 0
-    }
-    return result
-  }
 }
 
-async function addRouteRateHook (pluginComponent, params, routeOptions) {
+function mergeParams (...params) {
+  const result = Object.assign({}, ...params)
+  if (typeof result.timeWindow === 'string') {
+    result.timeWindow = ms.parse(result.timeWindow)
+  }
+  if (typeof result.timeWindow === 'number' && !isNaN(result.timeWindow)) {
+    result.timeWindowInSeconds = Math.floor(result.timeWindow / 1000)
+  }
+  return result
+}
+
+function addRouteRateHook (pluginComponent, params, routeOptions) {
   const hook = params.hook || defaultHook
-  const hookHandler = rateLimitRequestHandler(params, pluginComponent)
+  const hookHandler = rateLimitRequestHandler(pluginComponent, params)
   if (Array.isArray(routeOptions[hook])) {
     routeOptions[hook].push(hookHandler)
   } else if (typeof routeOptions[hook] === 'function') {
@@ -172,52 +155,41 @@ async function addRouteRateHook (pluginComponent, params, routeOptions) {
   }
 }
 
-function rateLimitRequestHandler (params, pluginComponent) {
-  const theStore = pluginComponent.store
-  return async function onRequestRateLimiter (req, res) {
-    const run = pluginComponent.run
-    const after = ms.format(params.timeWindow, true)
+function rateLimitRequestHandler (pluginComponent, params) {
+  const { rateLimitRan, store } = pluginComponent
 
-    if (req[run]) {
+  return async (req, res) => {
+    if (req[rateLimitRan]) {
       return
     }
-    req[run] = true
 
-    // We retrieve the key from the generator. (can be the global one, or the one define in the endpoint)
+    req[rateLimitRan] = true
+
+    // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     const key = await params.keyGenerator(req)
 
-    // allowList doesn't apply any rate limit
+    // Don't apply any rate limiting if in the allow list
     if (params.allowList) {
-      if (typeof pluginComponent.allowList === 'function') {
+      if (typeof params.allowList === 'function') {
         if (await params.allowList(req, key)) {
           return
         }
-      } else if (params.allowList.indexOf(key) > -1) {
+      } else if (params.allowList.indexOf(key) !== -1) {
         return
       }
     }
 
+    const max = typeof params.max === 'number' && !isNaN(params.max) ? params.max : await params.max(req, key)
     let current = 0
     let ttl = 0
+    let timeLeftInSeconds = 0
 
-    let maximum
-
-    if (typeof params.max === 'number' && !isNaN(params.max)) {
-      maximum = params.max
-    } else {
-      maximum = await params.max(req, key)
-    }
-
-    // As the key is not allowList in redis/lru, then we increment the rate-limit of the current request
+    // We increment the rate limit for the current request
     try {
-      const res = await new Promise(function (resolve, reject) {
-        theStore.incr(key, function (err, res) {
-          if (err) {
-            reject(err)
-            return
-          }
-          resolve(res)
-        }, maximum)
+      const res = await new Promise((resolve, reject) => {
+        store.incr(key, (err, res) => {
+          err ? reject(err) : resolve(res)
+        }, max)
       })
 
       current = res.current
@@ -228,12 +200,12 @@ function rateLimitRequestHandler (params, pluginComponent) {
       }
     }
 
-    const timeLeft = Math.ceil(ttl / 1000)
+    timeLeftInSeconds = Math.ceil(ttl / 1000)
 
-    if (current <= maximum) {
-      if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, maximum) }
-      if (params.addHeadersOnExceeding[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, maximum - current) }
-      if (params.addHeadersOnExceeding[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeft) }
+    if (current <= max) {
+      if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
+      if (params.addHeadersOnExceeding[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, max - current) }
+      if (params.addHeadersOnExceeding[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
 
       params.onExceeding?.(req, key)
 
@@ -242,17 +214,18 @@ function rateLimitRequestHandler (params, pluginComponent) {
 
     params.onExceeded?.(req, key)
 
-    if (params.addHeaders[params.labels.rateLimit]) { res.header(params.labels.rateLimit, maximum) }
+    if (params.addHeaders[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
     if (params.addHeaders[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, 0) }
-    if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeft) }
-    if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeft) }
+    if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
+    if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeftInSeconds) }
 
-    const code = params.ban && current - maximum > params.ban ? 403 : 429
+    const code = params.ban && current - max > params.ban ? 403 : 429
     const respCtx = {
       statusCode: code,
-      after,
-      max: maximum,
-      ttl
+      ban: false,
+      max,
+      ttl,
+      after: ms.format(params.timeWindow, true)
     }
 
     if (code === 403) {
@@ -263,6 +236,8 @@ function rateLimitRequestHandler (params, pluginComponent) {
     throw params.errorResponseBuilder(req, respCtx)
   }
 }
+
+function defaultKeyGenerator (req) { return req.ip }
 
 function defaultErrorResponse (req, context) {
   const err = new Error(`Rate limit exceeded, retry in ${context.after}`)

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -3,8 +3,8 @@
 function RedisStore (redis, timeWindow, continueExceeding, key) {
   this.redis = redis
   this.timeWindow = timeWindow
-  this.key = key
   this.continueExceeding = continueExceeding
+  this.key = key
 }
 
 RedisStore.prototype.incr = function (ip, cb, max) {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -1256,7 +1256,7 @@ test('Redis with continueExceeding should not always return the timeWindow as tt
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.ok(['0', '1', '2', '3'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '3')
 
   // After this sleep, we should not see `x-ratelimit-reset === 3` anymore
   await sleep(1000)
@@ -1265,7 +1265,7 @@ test('Redis with continueExceeding should not always return the timeWindow as tt
   t.equal(res.statusCode, 200)
   t.equal(res.headers['x-ratelimit-limit'], '2')
   t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.ok(['0', '1', '2'].includes(res.headers['x-ratelimit-reset']))
+  t.equal(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 429)

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1487,11 +1487,11 @@ test("child's allowList function should not crash and should override parent", a
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     global: false,
-    allowList: undefined
+    allowList: ['127.0.0.1']
   })
 
   fastify.get('/', {
-    config: { rateLimit: { allowList: () => true, max: 2, timeWindow: 10000 } }
+    config: { rateLimit: { allowList: () => false, max: 2, timeWindow: 10000 } }
   }, (req, reply) => {
     reply.send('hello!')
   })
@@ -1503,7 +1503,7 @@ test("child's allowList function should not crash and should override parent", a
   t.equal(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.equal(res.statusCode, 429)
 })
 
 test('rateLimit decorator should work when a property other than timeWindow is modified', async t => {
@@ -1529,4 +1529,16 @@ test('rateLimit decorator should work when a property other than timeWindow is m
 
   res = await fastify.inject('/')
   t.equal(res.statusCode, 200)
+
+  res = await fastify.inject({
+    path: '/',
+    remoteAddress: '1.1.1.1'
+  })
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject({
+    path: '/',
+    remoteAddress: '1.1.1.1'
+  })
+  t.equal(res.statusCode, 429)
 })

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1483,15 +1483,15 @@ test('on rateLimitHook should not be set twice on HEAD', async t => {
   }, async (req, reply) => 'fastify is awesome !')
 })
 
-test("child's allowList should override parent's function", async t => {
+test("child's allowList function should not crash and should override parent", async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     global: false,
-    allowList: (req, key) => false
+    allowList: undefined
   })
 
   fastify.get('/', {
-    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
+    config: { rateLimit: { allowList: () => true, max: 2, timeWindow: 10000 } }
   }, (req, reply) => {
     reply.send('hello!')
   })

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1483,6 +1483,29 @@ test('on rateLimitHook should not be set twice on HEAD', async t => {
   }, async (req, reply) => 'fastify is awesome !')
 })
 
+test("child's allowList function should not", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: () => false
+  })
+
+  fastify.get('/', {
+    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
 test("child's allowList function should not crash and should override parent", async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1482,3 +1482,51 @@ test('on rateLimitHook should not be set twice on HEAD', async t => {
     }
   }, async (req, reply) => 'fastify is awesome !')
 })
+
+test("child's allowList should override parent's function", async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    config: { rateLimit: { allowList: ['127.0.0.1'], max: 2, timeWindow: 10000 } }
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})
+
+test('rateLimit decorator should work when a property other than timeWindow is modified', async t => {
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    allowList: (req, key) => false
+  })
+
+  fastify.get('/', {
+    onRequest: fastify.rateLimit({
+      allowList: ['127.0.0.1'], max: 1
+    })
+  }, (req, reply) => {
+    reply.send('hello!')
+  })
+
+  let res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+
+  res = await fastify.inject('/')
+  t.equal(res.statusCode, 200)
+})

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1483,7 +1483,7 @@ test('on rateLimitHook should not be set twice on HEAD', async t => {
   }, async (req, reply) => 'fastify is awesome !')
 })
 
-test("child's allowList function should not", async t => {
+test("child's allowList should not crash the app", async t => {
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     global: false,


### PR DESCRIPTION
Here's what it fixes concretely:

- When a route's parent's `allowList` is a function and the child's isn't, the app will crash because the code makes a weird check to see if the *parent*'s parameter is a function and if so, calls `params.allowList` as a function (!), the params config's `allowList` can also be an array of IPs though (coming from the config object) and crash the app upon invocation

https://github.com/fastify/fastify-rate-limit/blob/18df4d3a33d32bf9c71f2d842117140e7e3b4bfc/index.js#L190-L198

- The rateLimit decorator also ignores the configuration when the `timeWindow` property isn't set. However, there might be times where we only want to change the max, or some other parameter

https://github.com/fastify/fastify-rate-limit/blob/18df4d3a33d32bf9c71f2d842117140e7e3b4bfc/index.js#L118-L123

Now, the decorator and the `config` property behave exactly the same

The reason for moving objects out of the main function is that, as this plugin supports being registered multiple times with multiple stores, we risk recreating these objects every single time

And finally, I tried to minimize the amount of intermediate objects that are created