### PR TITLE
RedisStore: don't return an object after error

### DIFF
--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -19,7 +19,7 @@ RedisStore.prototype.incr = function (ip, cb, max) {
      * result[1] => pttl response: [0]: error, [1]: ttl remaining
      */
       if (err || result[0][0] || result[1][0]) {
-        cb(err || result[0][0] || result[1][0], { current: 1, ttl: this.timeWindow })
+        cb(err || result[0][0] || result[1][0], null)
         return
       }
 


### PR DESCRIPTION
this doesn't change anything, it's better to return null because the information will be discarded anyway...