### PR TITLE
revert: handle ban in store

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,6 @@ function rateLimitRequestHandler (pluginComponent, params) {
     let current = 0
     let ttl = 0
     let timeLeftInSeconds = 0
-    let ban = false
 
     // We increment the rate limit for the current request
     try {
@@ -218,7 +217,6 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
       current = res.current
       ttl = res.ttl
-      ban = res.ban ?? (params.ban !== -1 && current - max > params.ban)
     } catch (err) {
       if (!params.skipOnError) {
         throw err
@@ -244,6 +242,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
     if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeftInSeconds) }
 
+    const ban = params.ban !== -1 && current - max > params.ban
     const respCtx = {
       statusCode: 429,
       ban,

--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       const res = await new Promise((resolve, reject) => {
         store.incr(key, (err, res) => {
           err ? reject(err) : resolve(res)
-        }, max, params.ban)
+        }, max)
       })
 
       current = res.current

--- a/index.js
+++ b/index.js
@@ -242,17 +242,17 @@ function rateLimitRequestHandler (pluginComponent, params) {
     if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
     if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeftInSeconds) }
 
-    const ban = params.ban !== -1 && current - max > params.ban
     const respCtx = {
       statusCode: 429,
-      ban,
+      ban: false,
       max,
       ttl,
       after: ms.format(params.timeWindow, true)
     }
 
-    if (ban) {
+    if (params.ban !== -1 && current - max > params.ban) {
       respCtx.statusCode = 403
+      respCtx.ban = true
       params.onBanReach?.(req, key)
     }
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -8,34 +8,29 @@ function LocalStore (cache = 5000, timeWindow, continueExceeding) {
   this.continueExceeding = continueExceeding
 }
 
-LocalStore.prototype.incr = function (ip, cb, max, ban) {
+LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
   let current = this.lru.get(ip)
 
-  if (!current) {
+  if (current === undefined) {
     // Item doesn't exist
-    current = { current: 1, ttl: this.timeWindow, ban: false, iterationStartMs: nowInMs }
+    current = { current: 1, ttl: this.timeWindow, iterationStartMs: nowInMs }
   } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
     // Item has expired
     current.current = 1
     current.ttl = this.timeWindow
-    current.ban = false
     current.iterationStartMs = nowInMs
   } else {
     // Item is alive
     ++current.current
 
     // Reset TLL if max has been exceeded and `continueExceeding` is enabled
-    if (this.continueExceeding && current.current > max) {
+    if (this.continueExceeding === true && current.current > max) {
       current.ttl = this.timeWindow
       current.iterationStartMs = nowInMs
     } else {
       current.ttl = this.timeWindow - (nowInMs - current.iterationStartMs)
     }
-  }
-
-  if (ban !== -1 && !current.ban && current.current - max > ban) {
-    current.ban = true
   }
 
   this.lru.set(ip, current)

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -12,7 +12,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
   const nowInMs = Date.now()
   let current = this.lru.get(ip)
 
-  if (current === undefined) {
+  if (!current) {
     // Item doesn't exist
     current = { current: 1, ttl: this.timeWindow, iterationStartMs: nowInMs }
   } else if (current.iterationStartMs + this.timeWindow <= nowInMs) {
@@ -25,7 +25,7 @@ LocalStore.prototype.incr = function (ip, cb, max) {
     ++current.current
 
     // Reset TLL if max has been exceeded and `continueExceeding` is enabled
-    if (this.continueExceeding === true && current.current > max) {
+    if (this.continueExceeding && current.current > max) {
       current.ttl = this.timeWindow
       current.iterationStartMs = nowInMs
     } else {

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -31,7 +31,7 @@ function RedisStore (redis, timeWindow, continueExceeding, key) {
   this.continueExceeding = continueExceeding
   this.key = key
 
-  if (!this.redis.rateLimit) {
+  if (this.redis.rateLimit === undefined) {
     this.redis.defineCommand('rateLimit', {
       numberOfKeys: 1,
       lua

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -41,7 +41,7 @@ function RedisStore (redis, timeWindow, continueExceeding, key) {
 
 RedisStore.prototype.incr = function (ip, cb, max) {
   this.redis.rateLimit(this.key + ip, this.timeWindow, max, this.continueExceeding, (err, result) => {
-    err != null ? cb(err, null) : cb(null, { current: result[0], ttl: result[1] })
+    err == null ? cb(null, { current: result[0], ttl: result[1] }) : cb(err, null)
   })
 }
 

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -18,8 +18,8 @@ const lua = `
 
   -- If the key is new or if its incremented value has exceeded the max value then set its TTL
   if ttl == -1 or (continueExceeding and current > max) then
-    ttl = timeWindow
     redis.call('PEXPIRE', key, timeWindow)
+    ttl = timeWindow
   end
 
   return {current, ttl}


### PR DESCRIPTION
Hey everyone,

The change that moved ban handling to the store-side **in a non-breaking manner** hasn't accomplished anything meaningful in terms of fixing the sync issue between multiple deployments when an in-memory counter is used, I basically misunderstood the problem

Naturally there will always be this issue with in-memory counters, and moving the ban calculation to the store just increased the network payload for Redis configurations, albeit a little bit

Now, I'm pretty sure not many people have custom stores that handle `ban` themselves, because the change is pretty new (a month old), but in any case, I will be targeting next to be sure