### PR TITLE
Report the correct TTL within the response context

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban,
       max,
       ttl,
-      after: ms.format(params.timeWindow, true)
+      after: ms.format(ttl, true)
     }
 
     if (ban) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const draftSpecHeaders = {
 const defaultKeyGenerator = (req) => req.ip
 
 const defaultErrorResponse = (req, context) => {
-  const err = new Error(`Rate limit exceeded, retry in ${context.ttlInSeconds} second(s)`)
+  const err = new Error(`Rate limit exceeded, retry in ${context.ttlInSeconds} second${context.ttlInSeconds !== 1 ? 's' : ''}}`)
   err.statusCode = context.statusCode
   return err
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const draftSpecHeaders = {
 const defaultKeyGenerator = (req) => req.ip
 
 const defaultErrorResponse = (req, context) => {
-  const err = new Error(`Rate limit exceeded, retry in ${context.after}`)
+  const err = new Error(`Rate limit exceeded, retry in ${context.ttlInSeconds} second(s)`)
   err.statusCode = context.statusCode
   return err
 }
@@ -249,7 +249,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban,
       max,
       ttl,
-      after: ms.format(ttlInSeconds * 1000, true)
+      ttlInSeconds
     }
 
     if (ban) {

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -723,7 +723,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 7 seconds'
+    message: 'Rate limit exceeded, retry in 7 second(s)'
   }, JSON.parse(res.payload))
 })
 

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -723,7 +723,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 7 second(s)'
+    message: 'Rate limit exceeded, retry in 7 seconds'
   }, JSON.parse(res.payload))
 })
 

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -723,7 +723,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 10 seconds'
+    message: 'Rate limit exceeded, retry in 7 seconds'
   }, JSON.parse(res.payload))
 })
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1022,7 +1022,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 10 seconds'
+    message: 'Rate limit exceeded, retry in 7 seconds'
   }, JSON.parse(res.payload))
 })
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1022,7 +1022,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 7 second(s)'
+    message: 'Rate limit exceeded, retry in 7 seconds'
   }, JSON.parse(res.payload))
 })
 

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1022,7 +1022,7 @@ test('With CustomStore', async t => {
   t.same({
     statusCode: 429,
     error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 7 seconds'
+    message: 'Rate limit exceeded, retry in 7 second(s)'
   }, JSON.parse(res.payload))
 })
 


### PR DESCRIPTION
respCtx would not report the real TTL but the static timeWindow

The reason we can't directly use ttl is that it's not ceiled so impossible to test consistently

I don't think we should be wasting time (however small it might be) on formatting text here

New:

```bash
Running 10s test @ http://127.0.0.1:3000
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.05 ms │ 12 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬──────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev    │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼──────────┼─────────┤
│ Req/Sec   │ 47,871  │ 47,871  │ 52,063  │ 52,351  │ 51,501.1 │ 1,243.97 │ 47,852  │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼──────────┼─────────┤
│ Bytes/Sec │ 18.1 MB │ 18.1 MB │ 19.7 MB │ 19.8 MB │ 19.5 MB  │ 474 kB   │ 18.1 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴──────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

100 2xx responses, 566412 non 2xx responses
567k requests in 11.01s, 214 MB read
```

Old:

```bash
Running 10s test @ http://127.0.0.1:3000
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.06 ms │ 11 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 45,567  │ 45,567  │ 51,007  │ 52,383  │ 50,457.6 │ 2,160.9 │ 45,561  │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 17.1 MB │ 17.1 MB │ 19.1 MB │ 19.6 MB │ 18.9 MB  │ 828 kB  │ 17.1 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 10

100 2xx responses, 504561 non 2xx responses
505k requests in 10.01s, 189 MB read
```

Benchmark:

```js
import fastify from 'fastify';

const app = fastify();

await app.register(import("../index.js"), {
    max: 100,
    timeWindow: '1 minute'
});

app.get('/', (request, reply) => {
    reply.send('Hello, world!');
});

app.listen(3000, (err) => {
    if (err) {
        console.error(err);
        process.exit(1);
    }
    console.log('Server is running on port 3000');
});
```