### PR TITLE
Revert workflow update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: fastify/workflows/.github/workflows/plugins-ci-redis.yml@v4
+    uses: fastify/workflows/.github/workflows/plugins-ci-redis.yml@v3
     with:
       license-check: true
       lint: true


### PR DESCRIPTION
I don't know why at the moment, but [centralized workflows for redis](https://github.com/fastify/workflows/blob/main/.github/workflows/plugins-ci-redis.yml) are failing

We should revert temporarily to v3