### PR TITLE
perf: use map for the in-memory store

### DIFF
--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Lru } = require('toad-cache')
+const { LruMap: Lru } = require('toad-cache')
 
 function LocalStore (cache = 5000, timeWindow, continueExceeding) {
   this.lru = new Lru(cache)


### PR DESCRIPTION
Reference: https://github.com/kibertoad/toad-cache/issues/40
Benchmark: https://github.com/kibertoad/nodejs-benchmark-tournament/pull/12

TLDR, I've discovered a 50%+ improvement in the lookup performance of non-numeric keys when a map is used instead of an object

In `rate-limit`, the key of a request is by default its IP address, so we should benefit directly from the change