### PR TITLE
refactor: make RedisStore default key a default parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,9 +102,9 @@ async function fastifyRateLimit (fastify, settings) {
     pluginComponent.store = new Store(globalParams)
   } else {
     if (settings.redis) {
-      pluginComponent.store = new RedisStore(settings.redis, globalParams.timeWindow, settings.continueExceeding, settings.nameSpace || 'fastify-rate-limit-')
+      pluginComponent.store = new RedisStore(settings.redis, settings.nameSpace, globalParams.timeWindow, globalParams.continueExceeding)
     } else {
-      pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, settings.continueExceeding)
+      pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, globalParams.continueExceeding)
     }
   }
 

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -25,11 +25,13 @@ const lua = `
   return {current, ttl}
 `
 
-function RedisStore (redis, timeWindow, continueExceeding, key) {
+function RedisStore (redis, key = 'fastify-rate-limit-', timeWindow, continueExceeding) {
+  if (!redis) throw new TypeError('Redis instance must be provided')
+
   this.redis = redis
+  this.key = key
   this.timeWindow = timeWindow
   this.continueExceeding = continueExceeding
-  this.key = key
 
   if (!this.redis.rateLimit) {
     this.redis.defineCommand('rateLimit', {
@@ -46,7 +48,7 @@ RedisStore.prototype.incr = function (ip, cb, max) {
 }
 
 RedisStore.prototype.child = function (routeOptions) {
-  return new RedisStore(this.redis, routeOptions.timeWindow, routeOptions.continueExceeding, this.key + routeOptions.routeInfo.method + routeOptions.routeInfo.url + '-')
+  return new RedisStore(this.redis, `${this.key}${routeOptions.routeInfo.method}${routeOptions.routeInfo.url}-`, routeOptions.timeWindow, routeOptions.continueExceeding)
 }
 
 module.exports = RedisStore

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -26,8 +26,6 @@ const lua = `
 `
 
 function RedisStore (redis, key = 'fastify-rate-limit-', timeWindow, continueExceeding) {
-  if (!redis) throw new TypeError('Redis instance must be provided')
-
   this.redis = redis
   this.key = key
   this.timeWindow = timeWindow


### PR DESCRIPTION
Small refactor that moves everything related to RedisStore to its own file, and uses the validated `globalParams` properties where possible