### PR TITLE
Add function support for timeWindow

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,11 +64,18 @@ async function fastifyRateLimit (fastify, settings) {
     : defaultMax
 
   // Global time window
-  globalParams.timeWindow = typeof settings.timeWindow === 'string'
-    ? ms.parse(settings.timeWindow)
-    : typeof settings.timeWindow === 'number' && Number.isFinite(settings.timeWindow) && settings.timeWindow >= 0
-      ? Math.trunc(settings.timeWindow)
-      : defaultTimeWindow
+  const twType = typeof settings.timeWindow
+  globalParams.timeWindow = defaultTimeWindow
+  if (twType === 'function') {
+    globalParams.timeWindow = settings.timeWindow
+  } else if (twType === 'string') {
+    globalParams.timeWindow = ms.parse(settings.timeWindow)
+  } else if (
+    twType === 'number' &&
+    Number.isFinite(settings.timeWindow) && settings.timeWindow >= 0
+  ) {
+    globalParams.timeWindow = Math.trunc(settings.timeWindow)
+  }
 
   globalParams.hook = settings.hook || defaultHook
   globalParams.allowList = settings.allowList || settings.whitelist || null
@@ -147,7 +154,7 @@ function mergeParams (...params) {
     result.timeWindow = ms.parse(result.timeWindow)
   } else if (typeof result.timeWindow === 'number' && Number.isFinite(result.timeWindow) && result.timeWindow >= 0) {
     result.timeWindow = Math.trunc(result.timeWindow)
-  } else {
+  } else if (typeof result.timeWindow !== 'function') {
     result.timeWindow = defaultTimeWindow
   }
 
@@ -180,7 +187,7 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 
 function rateLimitRequestHandler (pluginComponent, params) {
   const { rateLimitRan, store } = pluginComponent
-  const timeWindowString = ms.format(params.timeWindow, true)
+  const timeWindowString = ms.format(typeof params.timeWindow === 'function' ? params.timeWindow() : params.timeWindow, true)
 
   return async (req, res) => {
     if (req[rateLimitRan]) {
@@ -204,6 +211,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     }
 
     const max = typeof params.max === 'number' ? params.max : await params.max(req, key)
+    const timeWindow = typeof params.timeWindow === 'number' ? params.timeWindow : await params.timeWindow(req, key)
     let current = 0
     let ttl = 0
     let timeLeftInSeconds = 0
@@ -213,7 +221,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       const res = await new Promise((resolve, reject) => {
         store.incr(key, (err, res) => {
           err ? reject(err) : resolve(res)
-        }, max)
+        }, timeWindow, max)
       })
 
       current = res.current

--- a/index.js
+++ b/index.js
@@ -187,7 +187,6 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 
 function rateLimitRequestHandler (pluginComponent, params) {
   const { rateLimitRan, store } = pluginComponent
-  const timeWindowString = ms.format(typeof params.timeWindow === 'function' ? params.timeWindow() : params.timeWindow, true)
 
   return async (req, res) => {
     if (req[rateLimitRan]) {
@@ -256,7 +255,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban: false,
       max,
       ttl,
-      after: timeWindowString
+      after: ms.format(timeWindow, true)
     }
 
     if (params.ban !== -1 && current - max > params.ban) {

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -39,8 +39,8 @@ function RedisStore (redis, key = 'fastify-rate-limit-', timeWindow, continueExc
   }
 }
 
-RedisStore.prototype.incr = function (ip, cb, max) {
-  this.redis.rateLimit(this.key + ip, this.timeWindow, max, this.continueExceeding, (err, result) => {
+RedisStore.prototype.incr = function (ip, cb, timeWindow, max) {
+  this.redis.rateLimit(this.key + ip, timeWindow, max, this.continueExceeding, (err, result) => {
     err ? cb(err, null) : cb(null, { current: result[0], ttl: result[1] })
   })
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,10 +80,14 @@ declare namespace fastifyRateLimit {
 
   export interface RateLimitOptions {
     max?:
-    | number
-    | ((req: FastifyRequest, key: string) => number)
-    | ((req: FastifyRequest, key: string) => Promise<number>);
-    timeWindow?: number | string;
+      | number
+      | ((req: FastifyRequest, key: string) => number)
+      | ((req: FastifyRequest, key: string) => Promise<number>);
+    timeWindow?:
+      | number
+      | string
+      | ((req: FastifyRequest, key: string) => number)
+      | ((req: FastifyRequest, key: string) => Promise<number>);
     hook?: RateLimitHook;
     cache?: number;
     store?: FastifyRateLimitStoreCtor;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -114,6 +114,22 @@ const options6: RateLimitPluginOptions = {
   hook: 'preHandler'
 }
 
+const options7: RateLimitPluginOptions = {
+  global: true,
+  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => 42,
+  timeWindow: (req: FastifyRequest<RequestGenericInterface>, key: string) => 5000,
+  store: CustomStore,
+  hook: 'preValidation'
+}
+
+const options8: RateLimitPluginOptions = {
+  global: true,
+  max: (req: FastifyRequest<RequestGenericInterface>, key: string) => 42,
+  timeWindow: (req: FastifyRequest<RequestGenericInterface>, key: string) => Promise.resolve(5000),
+  store: CustomStore,
+  hook: 'preValidation'
+}
+
 appWithImplicitHttp.register(fastifyRateLimit, options1)
 appWithImplicitHttp.register(fastifyRateLimit, options2)
 appWithImplicitHttp.register(fastifyRateLimit, options5)
@@ -144,6 +160,8 @@ appWithHttp2.register(fastifyRateLimit, options1)
 appWithHttp2.register(fastifyRateLimit, options2)
 appWithHttp2.register(fastifyRateLimit, options3)
 appWithHttp2.register(fastifyRateLimit, options5)
+appWithHttp2.register(fastifyRateLimit, options7)
+appWithHttp2.register(fastifyRateLimit, options8)
 
 appWithHttp2.get('/public', {
   config: {


### PR DESCRIPTION
This update allows `timeWindow` to be a function that can dynamically determine the time window based on the request and key. The code refactor has been applied across both the Redis and Local stores. Tests for this new functionality have been added to ensure correctness. The TypeScript definition was also updated to reflect this change.

https://github.com/fastify/fastify-rate-limit/issues/283

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
