### PR TITLE
Use statusCode in errorResponseBuilder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ await fastify.register(import('@fastify/rate-limit'), {
   /* ... */
   errorResponseBuilder: function (request, context) {
     return {
-      code: 429,
+      statusCode: 429,
       error: 'Too Many Requests',
       message: `I only allow ${context.max} requests per ${context.after} to this Website. Try again soon.`,
       date: Date.now(),


### PR DESCRIPTION
Using `code:` in `errorResponseBuilder` results in a statusCode of a response to be 500. I believe it should be changed to `statusCode:` in example.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
