### PR TITLE
fix: remove unnecessary property `timeWindow` from RedisStore and LocalStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,9 @@ async function fastifyRateLimit (fastify, settings) {
     pluginComponent.store = new Store(globalParams)
   } else {
     if (settings.redis) {
-      pluginComponent.store = new RedisStore(settings.redis, settings.nameSpace, globalParams.timeWindow, globalParams.continueExceeding)
+      pluginComponent.store = new RedisStore(globalParams.continueExceeding, settings.redis, settings.nameSpace)
     } else {
-      pluginComponent.store = new LocalStore(settings.cache, globalParams.timeWindow, globalParams.continueExceeding)
+      pluginComponent.store = new LocalStore(globalParams.continueExceeding, settings.cache)
     }
   }
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -2,9 +2,9 @@
 
 const { LruMap: Lru } = require('toad-cache')
 
-function LocalStore (cache = 5000, timeWindow, continueExceeding) {
-  this.lru = new Lru(cache)
+function LocalStore (continueExceeding, cache = 5000) {
   this.continueExceeding = continueExceeding
+  this.lru = new Lru(cache)
 }
 
 LocalStore.prototype.incr = function (ip, cb, timeWindow, max) {
@@ -37,7 +37,7 @@ LocalStore.prototype.incr = function (ip, cb, timeWindow, max) {
 }
 
 LocalStore.prototype.child = function (routeOptions) {
-  return new LocalStore(routeOptions.cache, routeOptions.timeWindow, routeOptions.continueExceeding)
+  return new LocalStore(routeOptions.continueExceeding, routeOptions.cache)
 }
 
 module.exports = LocalStore

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -25,11 +25,10 @@ const lua = `
   return {current, ttl}
 `
 
-function RedisStore (redis, key = 'fastify-rate-limit-', timeWindow, continueExceeding) {
+function RedisStore (continueExceeding, redis, key = 'fastify-rate-limit-') {
+  this.continueExceeding = continueExceeding
   this.redis = redis
   this.key = key
-  this.timeWindow = timeWindow
-  this.continueExceeding = continueExceeding
 
   if (!this.redis.rateLimit) {
     this.redis.defineCommand('rateLimit', {
@@ -46,7 +45,7 @@ RedisStore.prototype.incr = function (ip, cb, timeWindow, max) {
 }
 
 RedisStore.prototype.child = function (routeOptions) {
-  return new RedisStore(this.redis, `${this.key}${routeOptions.routeInfo.method}${routeOptions.routeInfo.url}-`, routeOptions.timeWindow, routeOptions.continueExceeding)
+  return new RedisStore(routeOptions.continueExceeding, this.redis, `${this.key}${routeOptions.routeInfo.method}${routeOptions.routeInfo.url}-`)
 }
 
 module.exports = RedisStore


### PR DESCRIPTION
We no longer need to have a `timeWindow` property since it will be passed dynamically to the `incr` method