### PR TITLE
perf: pregenerate `timeWindow` string when possible and use `noop` as default function

### DIFF
--- a/example/example-simple.mjs
+++ b/example/example-simple.mjs
@@ -1,0 +1,25 @@
+import fastify from 'fastify'
+import fastifyRateLimit from '../index.js'
+
+const server = fastify()
+
+await server.register(fastifyRateLimit, {
+  global: true,
+  max: 10000,
+  timeWindow: '1 minute'
+})
+
+server.get('/', (request, reply) => {
+  reply.send('Hello, world!')
+})
+
+const start = async () => {
+  try {
+    await server.listen({ port: 3000 })
+    console.log('Server is running on port 3000')
+  } catch (error) {
+    console.error('Error starting server:', error)
+  }
+}
+
+start()

--- a/index.js
+++ b/index.js
@@ -188,6 +188,11 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
 function rateLimitRequestHandler (pluginComponent, params) {
   const { rateLimitRan, store } = pluginComponent
 
+  let timeWindowString
+  if (typeof params.timeWindow === 'number') {
+    timeWindowString = ms.format(params.timeWindow, true)
+  }
+
   return async (req, res) => {
     if (req[rateLimitRan]) {
       return
@@ -255,7 +260,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban: false,
       max,
       ttl,
-      after: ms.format(timeWindow, true)
+      after: timeWindowString ?? ms.format(timeWindow, true)
     }
 
     if (params.ban !== -1 && current - max > params.ban) {

--- a/index.js
+++ b/index.js
@@ -264,7 +264,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban: false,
       max,
       ttl,
-      after: timeWindowString || ms.format(timeWindow, true)
+      after: timeWindowString ?? ms.format(timeWindow, true)
     }
 
     if (params.ban !== -1 && current - max > params.ban) {

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
       current = res.current
       ttl = res.ttl
-      timeLeftInSeconds = Math.ceil(ttl / 1000)
+      timeLeftInSeconds = Math.ceil(res.ttl / 1000)
     } catch (err) {
       if (!params.skipOnError) {
         throw err

--- a/index.js
+++ b/index.js
@@ -235,13 +235,12 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
       current = res.current
       ttl = res.ttl
+      timeLeftInSeconds = Math.ceil(ttl / 1000)
     } catch (err) {
       if (!params.skipOnError) {
         throw err
       }
     }
-
-    timeLeftInSeconds = Math.ceil(ttl / 1000)
 
     if (current <= max) {
       if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
@@ -265,7 +264,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       ban: false,
       max,
       ttl,
-      after: timeWindowString ?? ms.format(timeWindow, true)
+      after: timeWindowString || ms.format(timeWindow, true)
     }
 
     if (params.ban !== -1 && current - max > params.ban) {

--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     const timeWindow = typeof params.timeWindow === 'number' ? params.timeWindow : await params.timeWindow(req, key)
     let current = 0
     let ttl = 0
-    let timeLeftInSeconds = 0
+    let ttlInSeconds = 0
 
     // We increment the rate limit for the current request
     try {
@@ -237,7 +237,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
       current = res.current
       ttl = res.ttl
-      timeLeftInSeconds = Math.ceil(res.ttl / 1000)
+      ttlInSeconds = Math.ceil(res.ttl / 1000)
     } catch (err) {
       if (!params.skipOnError) {
         throw err
@@ -247,7 +247,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
     if (current <= max) {
       if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
       if (params.addHeadersOnExceeding[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, max - current) }
-      if (params.addHeadersOnExceeding[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
+      if (params.addHeadersOnExceeding[params.labels.rateReset]) { res.header(params.labels.rateReset, ttlInSeconds) }
 
       params.onExceeding(req, key)
 
@@ -258,8 +258,8 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     if (params.addHeaders[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
     if (params.addHeaders[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, 0) }
-    if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, timeLeftInSeconds) }
-    if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, timeLeftInSeconds) }
+    if (params.addHeaders[params.labels.rateReset]) { res.header(params.labels.rateReset, ttlInSeconds) }
+    if (params.addHeaders[params.labels.retryAfter]) { res.header(params.labels.retryAfter, ttlInSeconds) }
 
     const respCtx = {
       statusCode: 429,


### PR DESCRIPTION
We shouldn't keep recreating the string if it's static, it might become a problem under an attack

**Note:** This was already the case, but it got removed in https://github.com/fastify/fastify-rate-limit/pull/357