### PR TITLE
[backport 9.x] fix: return type of rateLimit

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,15 +1,31 @@
 /// <reference types='node' />
 
 import {
+  ContextConfigDefault,
   FastifyPluginCallback,
   FastifyRequest,
+  FastifySchema,
   preHandlerAsyncHookHandler,
+  RouteGenericInterface,
   RouteOptions
 } from 'fastify';
 
 declare module 'fastify' {
-  interface FastifyInstance {
-    rateLimit: (options?: fastifyRateLimit.RateLimitOptions) => preHandlerAsyncHookHandler;
+  interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
+    rateLimit<
+      RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+      ContextConfig = ContextConfigDefault,
+      SchemaCompiler extends FastifySchema = FastifySchema,
+    >(options?: fastifyRateLimit.RateLimitOptions): preHandlerAsyncHookHandler<
+      RawServer,
+      RawRequest,
+      RawReply,
+      RouteGeneric,
+      ContextConfig,
+      SchemaCompiler,
+      TypeProvider,
+      Logger
+    >;
   }
   interface FastifyContextConfig {
     rateLimit?: fastifyRateLimit.RateLimitOptions | false;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -7,6 +7,7 @@ import fastify, {
 } from 'fastify'
 import * as http2 from 'http2'
 import { default as ioredis } from 'ioredis'
+import pino from 'pino';
 import fastifyRateLimit, {
   errorResponseBuilderContext,
   FastifyRateLimitOptions,
@@ -160,3 +161,15 @@ const errorResponseContext: errorResponseBuilderContext = {
   max: 1000,
   ttl: 123
 }
+const appWithCustomLogger = fastify({
+  logger: pino(),
+}).withTypeProvider()
+
+appWithCustomLogger.register(fastifyRateLimit, options1)
+
+appWithCustomLogger.route({
+  method: 'GET',
+  url: '/',
+  preHandler: appWithCustomLogger.rateLimit({}),
+  handler: () => {},
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Backports https://github.com/fastify/fastify-rate-limit/pull/375 to `9.x`

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
