### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,0 @@
-jobs: 1
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "standard --fix",
     "redis": "docker run -p 6379:6379 --name rate-limit-redis -d --rm redis",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -32,12 +32,12 @@
     "@fastify/pre-commit": "^2.1.0",
     "@sinonjs/fake-timers": "^11.2.2",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.3",
     "ioredis": "^5.4.1",
     "knex": "^3.1.0",
     "sqlite3": "^5.1.7",
     "standard": "^17.1.0",
-    "tap": "20.0.3",
     "tsd": "^0.31.1"
   },
   "dependencies": {

--- a/test/github-issues/issue-207.test.js
+++ b/test/github-issues/issue-207.test.js
@@ -1,37 +1,33 @@
 'use strict'
 
-const FakeTimers = require('@sinonjs/fake-timers')
-const t = require('tap')
-const test = t.test
+const { test, mock } = require('node:test')
 const Fastify = require('fastify')
 const rateLimit = require('../../index')
 
-t.beforeEach(t => {
-  t.context.clock = FakeTimers.install()
-})
-
-t.afterEach(t => {
-  t.context.clock.uninstall()
-})
-
-test('issue #207 - when continueExceeding is true and the store is local then it should reset the rate-limit', async t => {
+test('issue #207 - when continueExceeding is true and the store is local then it should reset the rate-limit', async (t) => {
+  const clock = mock.timers
+  clock.enable()
   const fastify = Fastify()
 
   await fastify.register(rateLimit, {
     global: false
   })
 
-  fastify.get('/', {
-    config: {
-      rateLimit: {
-        max: 1,
-        timeWindow: 5000,
-        continueExceeding: true
+  fastify.get(
+    '/',
+    {
+      config: {
+        rateLimit: {
+          max: 1,
+          timeWindow: 5000,
+          continueExceeding: true
+        }
       }
+    },
+    async () => {
+      return 'hello!'
     }
-  }, async () => {
-    return 'hello!'
-  })
+  )
 
   const firstOkResponse = await fastify.inject({
     url: '/',
@@ -42,7 +38,7 @@ test('issue #207 - when continueExceeding is true and the store is local then it
     method: 'GET'
   })
 
-  t.context.clock.tick(3000)
+  clock.tick(3000)
 
   const secondRateLimitWithResettingTheRateLimitTimer = await fastify.inject({
     url: '/',
@@ -50,7 +46,7 @@ test('issue #207 - when continueExceeding is true and the store is local then it
   })
 
   // after this the total time passed is 6s which WITHOUT `continueExceeding` the next request should be OK
-  t.context.clock.tick(3000)
+  clock.tick(3000)
 
   const thirdRateLimitWithResettingTheRateLimitTimer = await fastify.inject({
     url: '/',
@@ -58,29 +54,67 @@ test('issue #207 - when continueExceeding is true and the store is local then it
   })
 
   // After this the rate limiter should allow for new requests
-  t.context.clock.tick(5000)
+  clock.tick(5000)
 
   const okResponseAfterRateLimitCompleted = await fastify.inject({
     url: '/',
     method: 'GET'
   })
 
-  t.equal(firstOkResponse.statusCode, 200)
+  t.assert.deepStrictEqual(firstOkResponse.statusCode, 200)
 
-  t.equal(firstRateLimitResponse.statusCode, 429)
-  t.equal(firstRateLimitResponse.headers['x-ratelimit-limit'], '1')
-  t.equal(firstRateLimitResponse.headers['x-ratelimit-remaining'], '0')
-  t.equal(firstRateLimitResponse.headers['x-ratelimit-reset'], '5')
+  t.assert.deepStrictEqual(firstRateLimitResponse.statusCode, 429)
+  t.assert.deepStrictEqual(
+    firstRateLimitResponse.headers['x-ratelimit-limit'],
+    '1'
+  )
+  t.assert.deepStrictEqual(
+    firstRateLimitResponse.headers['x-ratelimit-remaining'],
+    '0'
+  )
+  t.assert.deepStrictEqual(
+    firstRateLimitResponse.headers['x-ratelimit-reset'],
+    '5'
+  )
 
-  t.equal(secondRateLimitWithResettingTheRateLimitTimer.statusCode, 429)
-  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'], '1')
-  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-remaining'], '0')
-  t.equal(secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'], '5')
+  t.assert.deepStrictEqual(
+    secondRateLimitWithResettingTheRateLimitTimer.statusCode,
+    429
+  )
+  t.assert.deepStrictEqual(
+    secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'],
+    '1'
+  )
+  t.assert.deepStrictEqual(
+    secondRateLimitWithResettingTheRateLimitTimer.headers[
+      'x-ratelimit-remaining'
+    ],
+    '0'
+  )
+  t.assert.deepStrictEqual(
+    secondRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'],
+    '5'
+  )
 
-  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.statusCode, 429)
-  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'], '1')
-  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-remaining'], '0')
-  t.equal(thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'], '5')
+  t.assert.deepStrictEqual(
+    thirdRateLimitWithResettingTheRateLimitTimer.statusCode,
+    429
+  )
+  t.assert.deepStrictEqual(
+    thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-limit'],
+    '1'
+  )
+  t.assert.deepStrictEqual(
+    thirdRateLimitWithResettingTheRateLimitTimer.headers[
+      'x-ratelimit-remaining'
+    ],
+    '0'
+  )
+  t.assert.deepStrictEqual(
+    thirdRateLimitWithResettingTheRateLimitTimer.headers['x-ratelimit-reset'],
+    '5'
+  )
 
-  t.equal(okResponseAfterRateLimitCompleted.statusCode, 200)
+  t.assert.deepStrictEqual(okResponseAfterRateLimitCompleted.statusCode, 200)
+  clock.reset(0)
 })

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -1,18 +1,15 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
-const Redis = require('ioredis')
+const { test, mock } = require('node:test')
 const Fastify = require('fastify')
 const rateLimit = require('../index')
-const FakeTimers = require('@sinonjs/fake-timers')
-const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
-const REDIS_HOST = '127.0.0.1'
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
-test('Basic', async t => {
+test('Basic', async (t) => {
   t.plan(15)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
 
@@ -22,43 +19,49 @@ test('Basic', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('With text timeWindow', async t => {
+test('With text timeWindow', async (t) => {
   t.plan(15)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, timeWindow: '1s' })
 
@@ -68,43 +71,49 @@ test('With text timeWindow', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('With function timeWindow', async t => {
+test('With function timeWindow', async (t) => {
   t.plan(15)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, timeWindow: (_, __) => 1000 })
 
@@ -114,45 +123,49 @@ test('With function timeWindow', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('When passing NaN to the timeWindow property then the timeWindow should be the default value - 60 seconds', async t => {
+test('When passing NaN to the timeWindow property then the timeWindow should be the default value - 60 seconds', async (t) => {
   t.plan(5)
-
-  t.context.clock = FakeTimers.install()
-
+  const clock = mock.timers
+  clock.enable(0)
   const defaultTimeWindowInSeconds = '60'
 
   const fastify = Fastify()
@@ -164,31 +177,33 @@ test('When passing NaN to the timeWindow property then the timeWindow should be 
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-reset'], defaultTimeWindowInSeconds)
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    defaultTimeWindowInSeconds
+  )
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 
   // Wait for almost 60s to make sure the time limit is right
-  t.context.clock.tick(55 * 1000)
+  clock.tick(55 * 1000)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 
   // Wait for the seconds that left until the time limit reset
-  t.context.clock.tick(5 * 1000)
+  clock.tick(5 * 1000)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  clock.reset()
 })
 
-test('With ips allowList, allowed ips should not result in rate limiting', async t => {
+test('With ips allowList, allowed ips should not result in rate limiting', async (t) => {
   t.plan(3)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -202,16 +217,16 @@ test('With ips allowList, allowed ips should not result in rate limiting', async
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 })
 
-test('With ips allowList, not allowed ips should result in rate limiting', async t => {
+test('With ips allowList, not allowed ips should result in rate limiting', async (t) => {
   t.plan(3)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -225,16 +240,16 @@ test('With ips allowList, not allowed ips should result in rate limiting', async
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With ips whitelist', async t => {
+test('With ips whitelist', async (t) => {
   t.plan(3)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -248,25 +263,27 @@ test('With ips whitelist', async t => {
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 })
 
-test('With function allowList', async t => {
+test('With function allowList', async (t) => {
   t.plan(18)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: '2s',
-    keyGenerator () { return 42 },
+    keyGenerator () {
+      return 42
+    },
     allowList: function (req, key) {
-      t.ok(req.headers)
-      t.equal(key, 42)
+      t.assert.ok(req.headers)
+      t.assert.deepStrictEqual(key, 42)
       return req.headers['x-my-header'] !== undefined
     }
   })
@@ -284,36 +301,38 @@ test('With function allowList', async t => {
   let res
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With async/await function allowList', async t => {
+test('With async/await function allowList', async (t) => {
   t.plan(18)
   const fastify = Fastify()
 
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: '2s',
-    keyGenerator () { return 42 },
+    keyGenerator () {
+      return 42
+    },
     allowList: async function (req, key) {
       await sleep(1)
-      t.ok(req.headers)
-      t.equal(key, 42)
+      t.assert.ok(req.headers)
+      t.assert.deepStrictEqual(key, 42)
       return req.headers['x-my-header'] !== undefined
     }
   })
@@ -331,32 +350,32 @@ test('With async/await function allowList', async t => {
   let res
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With onExceeding option', async t => {
+test('With onExceeding option', async (t) => {
   t.plan(5)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: '2s',
     onExceeding: function (req, key) {
-      if (req && key) t.pass('onExceeding called')
+      if (req && key) t.assert.ok('onExceeding called')
     }
   })
 
@@ -365,23 +384,23 @@ test('With onExceeding option', async t => {
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With onExceeded option', async t => {
+test('With onExceeded option', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: '2s',
     onExceeded: function (req, key) {
-      if (req && key) t.pass('onExceeded called')
+      if (req && key) t.assert.ok('onExceeded called')
     }
   })
 
@@ -390,23 +409,24 @@ test('With onExceeded option', async t => {
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With onBanReach option', async t => {
+test('With onBanReach option', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
     ban: 1,
     onBanReach: function (req) {
-      t.pass('onBanReach called')
+      // onBanReach called
+      t.assert.ok(req)
     }
   })
 
@@ -415,195 +435,25 @@ test('With onBanReach option', async t => {
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 403)
+  t.assert.deepStrictEqual(res.statusCode, 403)
 })
 
-test('With redis store', async t => {
+test('With keyGenerator', async (t) => {
   t.plan(19)
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-  await fastify.register(rateLimit, {
-    max: 2,
-    timeWindow: 1000,
-    redis
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  let res
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  await sleep(100)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
-
-  // Not using fake timers here as we use an external Redis that would not be effected by this
-  await sleep(1100)
-
-  res = await fastify.inject('/')
-
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  await redis.flushall()
-  await redis.quit()
-})
-
-test('With redis store (ban)', async t => {
-  t.plan(19)
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-  await fastify.register(rateLimit, {
-    max: 1,
-    ban: 1,
-    timeWindow: 1000,
-    redis
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  let res
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 403)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 403,
-    error: 'Forbidden',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
-
-  // Not using fake timers here as we use an external Redis that would not be effected by this
-  await sleep(1100)
-
-  res = await fastify.inject('/')
-
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  await redis.flushall()
-  await redis.quit()
-})
-
-test('Skip on redis error', async t => {
-  t.plan(9)
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-  await fastify.register(rateLimit, {
-    max: 2,
-    timeWindow: 1000,
-    redis,
-    skipOnError: true
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  let res
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  await redis.flushall()
-  await redis.quit()
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '2')
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '2')
-})
-
-test('Throw on redis error', async t => {
-  t.plan(5)
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-  await fastify.register(rateLimit, {
-    max: 2,
-    timeWindow: 1000,
-    redis,
-    skipOnError: false
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  let res
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  await redis.flushall()
-  await redis.quit()
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 500)
-  t.equal(res.body, '{"statusCode":500,"error":"Internal Server Error","message":"Connection is closed."}')
-})
-
-test('With keyGenerator', async t => {
-  t.plan(19)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: 1000,
     keyGenerator (req) {
-      t.equal(req.headers['my-custom-header'], 'random-value')
+      t.assert.deepStrictEqual(req.headers['my-custom-header'], 'random-value')
       return req.headers['my-custom-header']
     }
   })
@@ -621,45 +471,51 @@ test('With keyGenerator', async t => {
   let res
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('With async/await keyGenerator', async t => {
+test('With async/await keyGenerator', async (t) => {
+  t.plan(16)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
     timeWindow: 1000,
     keyGenerator: async function (req) {
       await sleep(1)
-      t.equal(req.headers['my-custom-header'], 'random-value')
+      t.assert.deepStrictEqual(req.headers['my-custom-header'], 'random-value')
       return req.headers['my-custom-header']
     }
   })
@@ -677,32 +533,38 @@ test('With async/await keyGenerator', async t => {
   let res
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
   await sleep(1100)
 
   res = await fastify.inject(payload)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 })
 
-test('With CustomStore', async t => {
+test('With CustomStore', async (t) => {
   t.plan(15)
 
   function CustomStore (options) {
@@ -713,11 +575,13 @@ test('With CustomStore', async t => {
   CustomStore.prototype.incr = function (key, cb) {
     const timeWindow = this.options.timeWindow
     this.current++
-    cb(null, { current: this.current, ttl: timeWindow - (this.current * 1000) })
+    cb(null, { current: this.current, ttl: timeWindow - this.current * 1000 })
   }
 
   CustomStore.prototype.child = function (routeOptions) {
-    const store = new CustomStore(Object.assign(this.options, routeOptions.config.rateLimit))
+    const store = new CustomStore(
+      Object.assign(this.options, routeOptions.config.rateLimit)
+    )
     return store
   }
 
@@ -734,34 +598,40 @@ test('With CustomStore', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '9')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '9')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '8')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '8')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '7')
-  t.equal(res.headers['retry-after'], '7')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 10 seconds'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '7')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '7')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 10 seconds'
+    },
+    JSON.parse(res.payload)
+  )
 })
 
-test('does not override the onRequest', async t => {
+test('does not override the onRequest', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -769,20 +639,24 @@ test('does not override the onRequest', async t => {
     timeWindow: 1000
   })
 
-  fastify.get('/', {
-    onRequest: function (req, reply, next) {
-      t.pass('onRequest called')
-      next()
-    }
-  }, async (req, reply) => 'hello!')
+  fastify.get(
+    '/',
+    {
+      onRequest: function (req, reply, next) {
+        t.assert.ok('onRequest called')
+        next()
+      }
+    },
+    async (req, reply) => 'hello!'
+  )
 
   const res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 })
 
-test('does not override the onRequest as an array', async t => {
+test('does not override the onRequest as an array', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -790,26 +664,32 @@ test('does not override the onRequest as an array', async t => {
     timeWindow: 1000
   })
 
-  fastify.get('/', {
-    onRequest: [function (req, reply, next) {
-      t.pass('onRequest called')
-      next()
-    }]
-  }, async (req, reply) => 'hello!')
+  fastify.get(
+    '/',
+    {
+      onRequest: [
+        function (req, reply, next) {
+          t.assert.ok('onRequest called')
+          next()
+        }
+      ]
+    },
+    async (req, reply) => 'hello!'
+  )
 
   const res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 })
 
-test('variable max', async t => {
+test('variable max', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: (req, key) => {
-      t.pass()
+      t.assert.ok(req)
       return +req.headers['secret-max']
     },
     timeWindow: 1000
@@ -819,17 +699,17 @@ test('variable max', async t => {
 
   const res = await fastify.inject({ url: '/', headers: { 'secret-max': 50 } })
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '50')
-  t.equal(res.headers['x-ratelimit-remaining'], '49')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '50')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '49')
 })
 
-test('variable max contenders', async t => {
+test('variable max contenders', async (t) => {
   t.plan(7)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     keyGenerator: (req) => req.headers['api-key'],
-    max: (req, key) => key === 'pro' ? 3 : 2,
+    max: (req, key) => (key === 'pro' ? 3 : 2),
     timeWindow: 10000
   })
 
@@ -847,11 +727,11 @@ test('variable max contenders', async t => {
 
   for (const item of requestSequence) {
     const res = await fastify.inject({ url: item.url, headers: item.headers })
-    t.equal(res.statusCode, item.status)
+    t.assert.deepStrictEqual(res.statusCode, item.status)
   }
 })
 
-test('when passing NaN to max variable then it should use the default max - 1000', async t => {
+test('when passing NaN to max variable then it should use the default max - 1000', async (t) => {
   t.plan(2002)
 
   const defaultMax = 1000
@@ -866,18 +746,19 @@ test('when passing NaN to max variable then it should use the default max - 1000
 
   for (let i = 0; i < defaultMax; i++) {
     const res = await fastify.inject('/')
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['x-ratelimit-limit'], '1000')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1000')
   }
 
   const res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['x-ratelimit-limit'], '1000')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1000')
 })
 
-test('hide rate limit headers', async t => {
+test('hide rate limit headers', async (t) => {
   t.plan(14)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
@@ -896,34 +777,50 @@ test('hide rate limit headers', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-  t.notOk(res.headers['retry-after'], 'the header must be missing')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['retry-after'],
+    'the header must be missing'
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
 
-  t.context.clock.uninstall()
+  clock.reset()
 })
 
-test('hide rate limit headers on exceeding', async t => {
+test('hide rate limit headers on exceeding', async (t) => {
   t.plan(14)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
@@ -941,35 +838,56 @@ test('hide rate limit headers on exceeding', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '1')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.not(res.headers['x-ratelimit-reset'], undefined)
-  t.equal(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.notStrictEqual(res.headers['x-ratelimit-reset'], undefined)
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
+  clock.reset()
 })
 
-test('hide rate limit headers at all times', async t => {
+test('hide rate limit headers at all times', async (t) => {
   t.plan(14)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
@@ -993,33 +911,65 @@ test('hide rate limit headers at all times', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-  t.notOk(res.headers['retry-after'], 'the header must be missing')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['retry-after'],
+    'the header must be missing'
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.notOk(res.headers['x-ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['x-ratelimit-reset'], 'the header must be missing')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['x-ratelimit-reset'],
+    'the header must be missing'
+  )
+  clock.reset()
 })
 
-test('With ban', async t => {
+test('With ban', async (t) => {
   t.plan(3)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
@@ -1032,44 +982,49 @@ test('With ban', async t => {
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
+  t.assert.deepStrictEqual(res.statusCode, 429)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 403)
+  t.assert.deepStrictEqual(res.statusCode, 403)
 })
 
-test('stops fastify lifecycle after onRequest and before preValidation', async t => {
+test('stops fastify lifecycle after onRequest and before preValidation', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 1, timeWindow: 1000 })
 
   let preValidationCallCount = 0
 
-  fastify.get('/', {
-    preValidation: function (req, reply, next) {
-      t.pass('preValidation called only once')
-      preValidationCallCount++
-      next()
-    }
-  },
-  async (req, reply) => 'hello!')
+  fastify.get(
+    '/',
+    {
+      preValidation: function (req, reply, next) {
+        t.assert.ok('preValidation called only once')
+        preValidationCallCount++
+        next()
+      }
+    },
+    async (req, reply) => 'hello!'
+  )
 
   let res
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.statusCode, 200)
 
   res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
-  t.equal(preValidationCallCount, 1)
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(preValidationCallCount, 1)
 })
 
-test('With enabled IETF Draft Spec', async t => {
+test('With enabled IETF Draft Spec', async (t) => {
   t.plan(16)
-  t.context.clock = FakeTimers.install()
+
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
@@ -1089,45 +1044,58 @@ test('With enabled IETF Draft Spec', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '2')
-  t.equal(res.headers['ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '2')
-  t.equal(res.headers['ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['ratelimit-limit'], '2')
-  t.equal(res.headers['ratelimit-remaining'], '0')
-  t.equal(res.headers['ratelimit-reset'], res.headers['retry-after'])
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(
+    res.headers['ratelimit-reset'],
+    res.headers['retry-after']
+  )
   const { ttl, ...payload } = JSON.parse(res.payload)
-  t.equal(res.headers['retry-after'], '' + Math.floor(ttl / 1000))
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, payload)
+  t.assert.deepStrictEqual(
+    res.headers['retry-after'],
+    '' + Math.floor(ttl / 1000)
+  )
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    payload
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '2')
-  t.equal(res.headers['ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('hide IETF draft spec headers', async t => {
+test('hide IETF draft spec headers', async (t) => {
   t.plan(14)
-  t.context.clock = FakeTimers.install()
+
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
@@ -1147,35 +1115,51 @@ test('hide IETF draft spec headers', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '1')
-  t.equal(res.headers['ratelimit-remaining'], '0')
-  t.equal(res.headers['ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['ratelimit-reset'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.notOk(res.headers['ratelimit-limit'], 'the header must be missing')
-  t.notOk(res.headers['ratelimit-remaining'], 'the header must be missing')
-  t.notOk(res.headers['ratelimit-reset'], 'the header must be missing')
-  t.notOk(res.headers['retry-after'], 'the header must be missing')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.notStrictEqual(
+    res.headers['ratelimit-limit'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['ratelimit-remaining'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['ratelimit-reset'],
+    'the header must be missing'
+  )
+  t.assert.notStrictEqual(
+    res.headers['retry-after'],
+    'the header must be missing'
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '1')
-  t.equal(res.headers['ratelimit-remaining'], '0')
-  t.equal(res.headers['ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['ratelimit-reset'], '1')
 
-  t.context.clock.uninstall()
+  clock.reset()
 })
 
-test('afterReset and Rate Limit remain the same when enableDraftSpec is enabled', async t => {
+test('afterReset and Rate Limit remain the same when enableDraftSpec is enabled', async (t) => {
   t.plan(13)
-  t.context.clock = FakeTimers.install()
+  const clock = mock.timers
+  clock.enable(0)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 1,
@@ -1187,32 +1171,34 @@ test('afterReset and Rate Limit remain the same when enableDraftSpec is enabled'
 
   const res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['ratelimit-limit'], '1')
-  t.equal(res.headers['ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
 
-  t.context.clock.tick(500)
+  clock.tick(500)
   await retry('10')
 
-  t.context.clock.tick(1000)
+  clock.tick(1000)
   await retry('9')
 
   async function retry (timeLeft) {
     const res = await fastify.inject('/')
 
-    t.equal(res.statusCode, 429)
-    t.equal(res.headers['ratelimit-limit'], '1')
-    t.equal(res.headers['ratelimit-remaining'], '0')
-    t.equal(res.headers['ratelimit-reset'], timeLeft)
-    t.equal(res.headers['ratelimit-reset'], res.headers['retry-after'])
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(res.headers['ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(res.headers['ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['ratelimit-reset'], timeLeft)
+    t.assert.deepStrictEqual(
+      res.headers['ratelimit-reset'],
+      res.headers['retry-after']
+    )
   }
-
-  t.context.clock.uninstall()
+  clock.reset()
 })
 
-test('Before async in "max"', async t => {
+test('Before async in "max"', async (t) => {
   const fastify = Fastify()
-  await await fastify.register(rateLimit, {
+  await fastify.register(rateLimit, {
     keyGenerator: (req) => req.headers['api-key'],
     max: async (req, key) => requestSequence(key),
     timeWindow: 10000
@@ -1220,10 +1206,10 @@ test('Before async in "max"', async t => {
 
   await fastify.get('/', async (req, res) => 'hello')
 
-  const requestSequence = async (key) => await key === 'pro' ? 5 : 2
+  const requestSequence = async (key) => ((await key) === 'pro' ? 5 : 2)
 })
 
-test('exposeHeadRoutes', async t => {
+test('exposeHeadRoutes', async (t) => {
   const fastify = Fastify({
     exposeHeadRoutes: true
   })
@@ -1243,16 +1229,36 @@ test('exposeHeadRoutes', async t => {
     method: 'HEAD'
   })
 
-  t.equal(res.statusCode, 200, 'GET: Response status code')
-  t.equal(res.headers['x-ratelimit-limit'], '10', 'GET: x-ratelimit-limit header (global rate limit)')
-  t.equal(res.headers['x-ratelimit-remaining'], '9', 'GET: x-ratelimit-remaining header (global rate limit)')
+  t.assert.deepStrictEqual(res.statusCode, 200, 'GET: Response status code')
+  t.assert.deepStrictEqual(
+    res.headers['x-ratelimit-limit'],
+    '10',
+    'GET: x-ratelimit-limit header (global rate limit)'
+  )
+  t.assert.deepStrictEqual(
+    res.headers['x-ratelimit-remaining'],
+    '9',
+    'GET: x-ratelimit-remaining header (global rate limit)'
+  )
 
-  t.equal(resHead.statusCode, 200, 'HEAD: Response status code')
-  t.equal(resHead.headers['x-ratelimit-limit'], '10', 'HEAD: x-ratelimit-limit header (global rate limit)')
-  t.equal(resHead.headers['x-ratelimit-remaining'], '8', 'HEAD: x-ratelimit-remaining header (global rate limit)')
+  t.assert.deepStrictEqual(
+    resHead.statusCode,
+    200,
+    'HEAD: Response status code'
+  )
+  t.assert.deepStrictEqual(
+    resHead.headers['x-ratelimit-limit'],
+    '10',
+    'HEAD: x-ratelimit-limit header (global rate limit)'
+  )
+  t.assert.deepStrictEqual(
+    resHead.headers['x-ratelimit-remaining'],
+    '8',
+    'HEAD: x-ratelimit-remaining header (global rate limit)'
+  )
 })
 
-test('When continue exceeding is on (Local)', async t => {
+test('When continue exceeding is on (Local)', async (t) => {
   const fastify = Fastify()
 
   await fastify.register(rateLimit, {
@@ -1272,168 +1278,15 @@ test('When continue exceeding is on (Local)', async t => {
     method: 'GET'
   })
 
-  t.equal(first.statusCode, 200)
+  t.assert.deepStrictEqual(first.statusCode, 200)
 
-  t.equal(second.statusCode, 429)
-  t.equal(second.headers['x-ratelimit-limit'], '1')
-  t.equal(second.headers['x-ratelimit-remaining'], '0')
-  t.equal(second.headers['x-ratelimit-reset'], '5')
+  t.assert.deepStrictEqual(second.statusCode, 429)
+  t.assert.deepStrictEqual(second.headers['x-ratelimit-limit'], '1')
+  t.assert.deepStrictEqual(second.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(second.headers['x-ratelimit-reset'], '5')
 })
 
-test('When continue exceeding is on (Redis)', async t => {
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-
-  await fastify.register(rateLimit, {
-    redis,
-    max: 1,
-    timeWindow: 5000,
-    continueExceeding: true
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  const first = await fastify.inject({
-    url: '/',
-    method: 'GET'
-  })
-  const second = await fastify.inject({
-    url: '/',
-    method: 'GET'
-  })
-
-  t.equal(first.statusCode, 200)
-
-  t.equal(second.statusCode, 429)
-  t.equal(second.headers['x-ratelimit-limit'], '1')
-  t.equal(second.headers['x-ratelimit-remaining'], '0')
-  t.equal(second.headers['x-ratelimit-reset'], '5')
-
-  await redis.flushall()
-  await redis.quit()
-})
-
-test('Redis with continueExceeding should not always return the timeWindow as ttl', async t => {
-  t.plan(19)
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-  await fastify.register(rateLimit, {
-    max: 2,
-    timeWindow: 3000,
-    continueExceeding: true,
-    redis
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  let res
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '3')
-
-  // After this sleep, we should not see `x-ratelimit-reset === 3` anymore
-  await sleep(1000)
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
-
-  res = await fastify.inject('/')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '3')
-  t.equal(res.headers['retry-after'], '3')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 3 seconds'
-  }, JSON.parse(res.payload))
-
-  // Not using fake timers here as we use an external Redis that would not be effected by this
-  await sleep(1000)
-
-  res = await fastify.inject('/')
-
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '3')
-
-  await redis.flushall()
-  await redis.quit()
-})
-
-test('When use a custom nameSpace', async t => {
-  const fastify = Fastify()
-  const redis = new Redis({ host: REDIS_HOST })
-
-  await fastify.register(rateLimit, {
-    max: 2,
-    timeWindow: 1000,
-    redis,
-    nameSpace: 'my-namespace:',
-    keyGenerator: (req) => req.headers['x-my-header']
-  })
-
-  fastify.get('/', async (req, reply) => 'hello!')
-
-  const allowListHeader = {
-    method: 'GET',
-    url: '/',
-    headers: {
-      'x-my-header': 'custom name space'
-    }
-  }
-
-  let res
-
-  res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  res = await fastify.inject(allowListHeader)
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
-
-  // Not using fake timers here as we use an external Redis that would not be effected by this
-  await sleep(1100)
-
-  res = await fastify.inject(allowListHeader)
-
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-
-  await redis.flushall()
-  await redis.quit()
-})
-
-test('on preHandler hook', async t => {
+test('on preHandler hook', async (t) => {
   const fastify = Fastify()
 
   await fastify.register(rateLimit, {
@@ -1446,7 +1299,7 @@ test('on preHandler hook', async t => {
   })
 
   fastify.decorateRequest('userId', '')
-  fastify.addHook('preHandler', async req => {
+  fastify.addHook('preHandler', async (req) => {
     const { userId } = req.query
     if (userId) {
       req.userId = userId
@@ -1455,7 +1308,7 @@ test('on preHandler hook', async t => {
 
   fastify.get('/', async (req, reply) => 'fastify is awesome !')
 
-  const send = userId => {
+  const send = (userId) => {
     let query
     if (userId) {
       query = { userId }
@@ -1472,16 +1325,19 @@ test('on preHandler hook', async t => {
   const fourth = await send('123')
   const fifth = await send('234')
 
-  t.equal(first.statusCode, 200)
-  t.equal(second.statusCode, 429)
-  t.equal(third.statusCode, 200)
-  t.equal(fourth.statusCode, 429)
-  t.equal(fifth.statusCode, 200)
+  t.assert.deepStrictEqual(first.statusCode, 200)
+  t.assert.deepStrictEqual(second.statusCode, 429)
+  t.assert.deepStrictEqual(third.statusCode, 200)
+  t.assert.deepStrictEqual(fourth.statusCode, 429)
+  t.assert.deepStrictEqual(fifth.statusCode, 200)
 })
 
-test('ban directly', async t => {
+test('ban directly', async (t) => {
   t.plan(15)
-  t.context.clock = FakeTimers.install()
+
+  const clock = mock.timers
+  clock.enable(0)
+
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, ban: 0, timeWindow: '1s' })
 
@@ -1491,88 +1347,105 @@ test('ban directly', async t => {
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 403)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '1')
-  t.same({
-    statusCode: 403,
-    error: 'Forbidden',
-    message: 'Rate limit exceeded, retry in 1 second'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 403)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 403,
+      error: 'Forbidden',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  clock.reset()
 })
 
-test('wrong timewindow', async t => {
+test('wrong timewindow', async (t) => {
   t.plan(15)
-  t.context.clock = FakeTimers.install()
+
+  const clock = mock.timers
+  clock.enable(0)
+
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, ban: 0, timeWindow: '1s' })
 
-  fastify.get('/', {
-    config: {
-      rateLimit: {
-        timeWindow: -5
+  fastify.get(
+    '/',
+    {
+      config: {
+        rateLimit: {
+          timeWindow: -5
+        }
       }
-    }
-  }, async (req, reply) => 'hello!')
+    },
+    async (req, reply) => 'hello!'
+  )
 
   let res
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 200)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 403)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '60')
-  t.same({
-    statusCode: 403,
-    error: 'Forbidden',
-    message: 'Rate limit exceeded, retry in 1 minute'
-  }, JSON.parse(res.payload))
+  t.assert.deepStrictEqual(res.statusCode, 403)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '60')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 403,
+      error: 'Forbidden',
+      message: 'Rate limit exceeded, retry in 1 minute'
+    },
+    JSON.parse(res.payload)
+  )
 
-  t.context.clock.tick(1100)
+  clock.tick(1100)
 
   res = await fastify.inject('/')
 
-  t.equal(res.statusCode, 403)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-
-  t.context.clock.uninstall()
+  t.assert.deepStrictEqual(res.statusCode, 403)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  clock.reset()
 })

--- a/test/local-store-close.test.js
+++ b/test/local-store-close.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const rateLimit = require('../index')
 
-test('Fastify close on local store', async t => {
+test('Fastify close on local store', async (t) => {
   t.plan(1)
   const fastify = Fastify()
   await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
@@ -15,5 +14,5 @@ test('Fastify close on local store', async t => {
     done()
   })
   await fastify.close()
-  t.equal(counter, 2)
+  t.assert.deepStrictEqual(counter, 2)
 })

--- a/test/not-found-handler-rate-limited.test.js
+++ b/test/not-found-handler-rate-limited.test.js
@@ -1,103 +1,114 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const rateLimit = require('../index')
 
-test('Set not found handler can be rate limited', async t => {
+test('Set not found handler can be rate limited', async (t) => {
   t.plan(18)
 
   const fastify = Fastify()
 
   await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
-  t.ok(fastify.rateLimit)
+  t.assert.ok(fastify.rateLimit)
 
-  fastify.setNotFoundHandler({
-    preHandler: fastify.rateLimit()
-  }, function (request, reply) {
-    t.pass('Error handler has been called')
-    reply.status(404).send(new Error('Not found'))
-  })
+  fastify.setNotFoundHandler(
+    {
+      preHandler: fastify.rateLimit()
+    },
+    function (request, reply) {
+      t.assert.ok('Error handler has been called')
+      reply.status(404).send(new Error('Not found'))
+    }
+  )
 
   let res
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '2')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '1')
-  t.equal(res.headers['retry-after'], '1')
-  t.same(JSON.parse(res.payload), {
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',
     message: 'Rate limit exceeded, retry in 1 second'
   })
 })
 
-test('Set not found handler can be rate limited with specific options', async t => {
+test('Set not found handler can be rate limited with specific options', async (t) => {
   t.plan(28)
 
   const fastify = Fastify()
 
   await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
-  t.ok(fastify.rateLimit)
+  t.assert.ok(fastify.rateLimit)
 
-  fastify.setNotFoundHandler({
-    preHandler: fastify.rateLimit({
-      max: 4,
-      timeWindow: 2000
-    })
-  }, function (request, reply) {
-    t.pass('Error handler has been called')
-    reply.status(404).send(new Error('Not found'))
-  })
+  fastify.setNotFoundHandler(
+    {
+      preHandler: fastify.rateLimit({
+        max: 4,
+        timeWindow: 2000
+      })
+    },
+    function (request, reply) {
+      t.assert.ok('Error handler has been called')
+      reply.status(404).send(new Error('Not found'))
+    }
+  )
 
   let res
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '4')
-  t.equal(res.headers['x-ratelimit-remaining'], '3')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '4')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '3')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '4')
-  t.equal(res.headers['x-ratelimit-remaining'], '2')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '4')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '4')
-  t.equal(res.headers['x-ratelimit-remaining'], '1')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '4')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 404)
-  t.equal(res.headers['x-ratelimit-limit'], '4')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
+  t.assert.deepStrictEqual(res.statusCode, 404)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '4')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
 
   res = await fastify.inject('/not-found')
-  t.equal(res.statusCode, 429)
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.headers['x-ratelimit-limit'], '4')
-  t.equal(res.headers['x-ratelimit-remaining'], '0')
-  t.equal(res.headers['retry-after'], '2')
-  t.equal(res.headers['x-ratelimit-reset'], '2')
-  t.same(JSON.parse(res.payload), {
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '4')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
+  t.assert.deepStrictEqual(JSON.parse(res.payload), {
     statusCode: 429,
     error: 'Too Many Requests',
     message: 'Rate limit exceeded, retry in 2 seconds'

--- a/test/redis-rate-limit.test.js
+++ b/test/redis-rate-limit.test.js
@@ -1,0 +1,613 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const Redis = require('ioredis')
+const Fastify = require('fastify')
+const rateLimit = require('../index')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const REDIS_HOST = '127.0.0.1'
+
+describe('Global rate limit', () => {
+  test('With redis store', async (t) => {
+    t.plan(21)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      redis
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.ok(res)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await sleep(100)
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(
+      res.headers['content-type'],
+      'application/json; charset=utf-8'
+    )
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+    t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+    t.assert.deepStrictEqual(
+      {
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded, retry in 1 second'
+      },
+      JSON.parse(res.payload)
+    )
+
+    // Not using fake timers here as we use an external Redis that would not be effected by this
+    await sleep(1100)
+
+    res = await fastify.inject('/')
+
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('With redis store (ban)', async (t) => {
+    t.plan(19)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      max: 1,
+      ban: 1,
+      timeWindow: 1000,
+      redis
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 403)
+    t.assert.deepStrictEqual(
+      res.headers['content-type'],
+      'application/json; charset=utf-8'
+    )
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+    t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+    t.assert.deepStrictEqual(
+      {
+        statusCode: 403,
+        error: 'Forbidden',
+        message: 'Rate limit exceeded, retry in 1 second'
+      },
+      JSON.parse(res.payload)
+    )
+
+    // Not using fake timers here as we use an external Redis that would not be effected by this
+    await sleep(1100)
+
+    res = await fastify.inject('/')
+
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('Skip on redis error', async (t) => {
+    t.plan(9)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      redis,
+      skipOnError: true
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '2')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '2')
+  })
+
+  test('Throw on redis error', async (t) => {
+    t.plan(5)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      redis,
+      skipOnError: false
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 500)
+    t.assert.deepStrictEqual(
+      res.body,
+      '{"statusCode":500,"error":"Internal Server Error","message":"Connection is closed."}'
+    )
+  })
+
+  test('When continue exceeding is on (Redis)', async (t) => {
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+
+    await fastify.register(rateLimit, {
+      redis,
+      max: 1,
+      timeWindow: 5000,
+      continueExceeding: true
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    const first = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+    const second = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+
+    t.assert.deepStrictEqual(first.statusCode, 200)
+
+    t.assert.deepStrictEqual(second.statusCode, 429)
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-reset'], '5')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('Redis with continueExceeding should not always return the timeWindow as ttl', async (t) => {
+    t.plan(19)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 3000,
+      continueExceeding: true,
+      redis
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '3')
+
+    // After this sleep, we should not see `x-ratelimit-reset === 3` anymore
+    await sleep(1000)
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '2')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(
+      res.headers['content-type'],
+      'application/json; charset=utf-8'
+    )
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '3')
+    t.assert.deepStrictEqual(res.headers['retry-after'], '3')
+    t.assert.deepStrictEqual(
+      {
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded, retry in 3 seconds'
+      },
+      JSON.parse(res.payload)
+    )
+
+    // Not using fake timers here as we use an external Redis that would not be effected by this
+    await sleep(1000)
+
+    res = await fastify.inject('/')
+
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '3')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('When use a custom nameSpace', async (t) => {
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      redis,
+      nameSpace: 'my-namespace:',
+      keyGenerator: (req) => req.headers['x-my-header']
+    })
+
+    fastify.get('/', async (req, reply) => 'hello!')
+
+    const allowListHeader = {
+      method: 'GET',
+      url: '/',
+      headers: {
+        'x-my-header': 'custom name space'
+      }
+    }
+
+    let res
+
+    res = await fastify.inject(allowListHeader)
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject(allowListHeader)
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject(allowListHeader)
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(
+      res.headers['content-type'],
+      'application/json; charset=utf-8'
+    )
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+    t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+    t.assert.deepStrictEqual(
+      {
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded, retry in 1 second'
+      },
+      JSON.parse(res.payload)
+    )
+
+    // Not using fake timers here as we use an external Redis that would not be effected by this
+    await sleep(1100)
+
+    res = await fastify.inject(allowListHeader)
+
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+})
+
+describe('Route rate limit', () => {
+  test('With redis store', async t => {
+    t.plan(19)
+    const fastify = Fastify()
+    const redis = new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      global: false,
+      redis
+    })
+
+    fastify.get('/', {
+      config: {
+        rateLimit: {
+          max: 2,
+          timeWindow: 1000
+        },
+        someOtherPlugin: {
+          someValue: 1
+        }
+      }
+    }, async (req, reply) => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.strictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.strictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.strictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.strictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 429)
+    t.assert.strictEqual(res.headers['content-type'], 'application/json; charset=utf-8')
+    t.assert.strictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.strictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.strictEqual(res.headers['x-ratelimit-reset'], '1')
+    t.assert.strictEqual(res.headers['retry-after'], '1')
+    t.assert.deepStrictEqual({
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    }, JSON.parse(res.payload))
+
+    // Not using fake timers here as we use an external Redis that would not be effected by this
+    await sleep(1100)
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.strictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.strictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('Throw on redis error', async (t) => {
+    t.plan(6)
+    const fastify = Fastify()
+    const redis = new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      redis,
+      global: false
+    })
+
+    fastify.get(
+      '/',
+      {
+        config: {
+          rateLimit: {
+            max: 2,
+            timeWindow: 1000,
+            skipOnError: false
+          }
+        }
+      },
+      async (req, reply) => 'hello!'
+    )
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 500)
+    t.assert.deepStrictEqual(
+      res.body,
+      '{"statusCode":500,"error":"Internal Server Error","message":"Connection is closed."}'
+    )
+  })
+
+  test('Skip on redis error', async (t) => {
+    t.plan(9)
+    const fastify = Fastify()
+    const redis = new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      redis,
+      global: false
+    })
+
+    fastify.get(
+      '/',
+      {
+        config: {
+          rateLimit: {
+            max: 2,
+            timeWindow: 1000,
+            skipOnError: true
+          }
+        }
+      },
+      async (req, reply) => 'hello!'
+    )
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+    await redis.flushall()
+    await redis.quit()
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '2')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '2')
+  })
+
+  test('When continue exceeding is on (Redis)', async (t) => {
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+
+    await fastify.register(rateLimit, {
+      global: false,
+      redis
+    })
+
+    fastify.get(
+      '/',
+      {
+        config: {
+          rateLimit: {
+            timeWindow: 5000,
+            max: 1,
+            continueExceeding: true
+          }
+        }
+      },
+      async (req, reply) => 'hello!'
+    )
+
+    const first = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+    const second = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+
+    t.assert.deepStrictEqual(first.statusCode, 200)
+
+    t.assert.deepStrictEqual(second.statusCode, 429)
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-reset'], '5')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('When continue exceeding is off under route (Redis)', async (t) => {
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+
+    await fastify.register(rateLimit, {
+      global: false,
+      continueExceeding: true,
+      redis
+    })
+
+    fastify.get(
+      '/',
+      {
+        config: {
+          rateLimit: {
+            timeWindow: 5000,
+            max: 1,
+            continueExceeding: false
+          }
+        }
+      },
+      async (req, reply) => 'hello!'
+    )
+
+    const first = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+    const second = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+
+    await sleep(2000)
+
+    const third = await fastify.inject({
+      url: '/',
+      method: 'GET'
+    })
+
+    t.assert.deepStrictEqual(first.statusCode, 200)
+
+    t.assert.deepStrictEqual(second.statusCode, 429)
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(second.headers['x-ratelimit-reset'], '5')
+
+    t.assert.deepStrictEqual(third.statusCode, 429)
+    t.assert.deepStrictEqual(third.headers['x-ratelimit-limit'], '1')
+    t.assert.deepStrictEqual(third.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(third.headers['x-ratelimit-reset'], '3')
+
+    await redis.flushall()
+    await redis.quit()
+  })
+})


### PR DESCRIPTION
#### Checklist

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
