### PR TITLE
Added grouping routes for ratelimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,31 @@ fastify.get('/public/sub-rated-1', {
 }, (request, reply) => {
   reply.send({ hello: 'from sub-rated-1 ... using default max value ... ' })
 })
+
+// gorup routes and add a rate limit
+fastify.get('/otp/send', {
+  config: {
+    rateLimit: {
+      max: 3,
+      timeWindow: '1 minute',
+      groupId:"OTP"
+    }
+  }
+}, (request, reply) => {
+  reply.send({ hello: 'from ... grouped rate limit' })
+})
+
+fastify.get('/otp/resend', {
+  config: {
+    rateLimit: {
+      max: 3,
+      timeWindow: '1 minute',
+      groupId:"OTP"
+    }
+  }
+}, (request, reply) => {
+  reply.send({ hello: 'from ... grouped rate limit' })
+})
 ```
 
 In the route creation you can override the same settings of the plugin registration plus the following additional options:

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     let key = await params.keyGenerator(req)
-    const groupId = req?.routeConfig?.rateLimit?.groupId
+    const groupId = req?.routeOptions?.config?.rateLimit?.groupId
 
     if (groupId) {
       key += groupId

--- a/index.js
+++ b/index.js
@@ -144,14 +144,13 @@ async function fastifyRateLimit (fastify, settings) {
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
         newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
 
-        if(routeOptions?.config?.rateLimit?.groupId){
-          const groupId = routeOptions.config.rateLimit.groupId;
-          if(typeof groupId == 'string'){
+        if (routeOptions?.config?.rateLimit?.groupId) {
+          const groupId = routeOptions.config.rateLimit.groupId
+          if (typeof groupId === 'string') {
             addRouteRateHook(pluginComponent, globalParams, routeOptions)
           } else {
-            throw new Error('groupId must be a string');
+            throw new Error('groupId must be a string')
           }
-    
         } else {
           addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
         }
@@ -220,10 +219,10 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     let key = await params.keyGenerator(req)
-    const groupId = req?.routeConfig?.rateLimit?.groupId;
+    const groupId = req?.routeConfig?.rateLimit?.groupId
 
-    if(groupId){
-      key+=groupId
+    if (groupId) {
+      key += groupId
     }
 
     // Don't apply any rate limiting if in the allow list

--- a/index.js
+++ b/index.js
@@ -143,7 +143,18 @@ async function fastifyRateLimit (fastify, settings) {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
         newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
-        addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
+
+        if(routeOptions?.config?.rateLimit?.groupId){
+          const groupId = routeOptions.config.rateLimit.groupId;
+          if(typeof groupId == 'string'){
+            addRouteRateHook(pluginComponent, globalParams, routeOptions)
+          } else {
+            throw new Error('groupId must be a string');
+          }
+    
+        } else {
+          addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
+        }
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')
       }
@@ -208,7 +219,12 @@ function rateLimitRequestHandler (pluginComponent, params) {
     req[rateLimitRan] = true
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
-    const key = await params.keyGenerator(req)
+    let key = await params.keyGenerator(req)
+    const groupId = req?.routeConfig?.rateLimit?.groupId;
+
+    if(groupId){
+      key+=groupId
+    }
 
     // Don't apply any rate limiting if in the allow list
     if (params.allowList) {

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -1,0 +1,114 @@
+const { test, mock } = require('node:test')
+const Fastify = require('fastify')
+const rateLimit = require('../index')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('With multiple routes and custom groupId', async (t) => {
+  t.plan(22)
+  const clock = mock.timers
+  clock.enable(0)
+  const fastify = Fastify()
+  
+  // Register rate limit plugin
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
+
+  // Route 1 with groupId 'group1'
+  fastify.get('/route1', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1000,
+        groupId: 'group1'
+      }
+    }
+  }, async (req, reply) => 'hello from route 1!')
+
+  // Route 2 with groupId 'group2'
+  fastify.get('/route2', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1000,
+        groupId: 'group2'
+      }
+    }
+  }, async (req, reply) => 'hello from route 2!')
+
+  let res
+
+  // Test Route 1
+  res = await fastify.inject('/route1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+  res = await fastify.inject('/route1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+
+  res = await fastify.inject('/route1')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
+
+  // Test Route 2
+  res = await fastify.inject('/route2')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+  res = await fastify.inject('/route2')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+
+  res = await fastify.inject('/route2')
+  t.assert.deepStrictEqual(res.statusCode, 429)
+  t.assert.deepStrictEqual(
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  t.assert.deepStrictEqual(
+    {
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 1 second'
+    },
+    JSON.parse(res.payload)
+  )
+
+  // Wait for the window to reset
+  clock.tick(1100)
+
+  // After reset, Route 1 should succeed again
+  res = await fastify.inject('/route1')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+  // Route 2 should also succeed after the reset
+  res = await fastify.inject('/route2')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+  clock.reset()
+})

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -114,3 +114,28 @@ test('With multiple routes and custom groupId', async (t) => {
 
   clock.reset()
 })
+
+test('Invalid groupId type', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  // Register rate limit plugin with a route having an invalid groupId
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
+
+  fastify.get('/invalidGroupId', {
+    config: {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1000,
+        groupId: 123 // Invalid groupId type
+      }
+    }
+  }, async (req, reply) => 'hello with invalid groupId!')
+
+  try {
+    await fastify.inject('/invalidGroupId')
+    t.fail('Expected an error to be thrown')
+  } catch (err) {
+    t.assert(err.message.includes('groupId must be a string'))
+  }
+})

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -135,6 +135,6 @@ test('Invalid groupId type', async (t) => {
     await fastify.inject('/invalidGroupId')
     t.fail('should throw')
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, ('groupId must be a string'))
+    t.assert.deepStrictEqual(err.message, 'groupId must be a string')
   }
 })

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -1,140 +1,148 @@
-const { test, mock } = require('node:test')
-const Fastify = require('fastify')
-const rateLimit = require('../index')
+"use strict";
+const { test, mock } = require("node:test");
+const assert = require("assert");
+const Fastify = require("fastify");
+const rateLimit = require("../index");
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
-test('With multiple routes and custom groupId', async (t) => {
-  const clock = mock.timers
-  clock.enable(0)
-  const fastify = Fastify()
+
+test("With multiple routes and custom groupId", async (t) => {
+  const fastify = Fastify();
 
   // Register rate limit plugin
-  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
+  await fastify.register(rateLimit, { max: 2, timeWindow: 500 });
 
   // Route 1 with groupId 'group1'
-  fastify.get('/route1', {
-    config: {
-      rateLimit: {
-        max: 2,
-        timeWindow: 1000,
-        groupId: 'group1'
-      }
-    }
-  }, async (req, reply) => 'hello from route 1!')
+  fastify.get(
+    "/route1",
+    {
+      config: {
+        rateLimit: {
+          max: 2,
+          timeWindow: 500,
+          groupId: "group1",
+        },
+      },
+    },
+    async (req, reply) => "hello from route 1!"
+  );
 
   // Route 2 with groupId 'group2'
-  fastify.get('/route2', {
-    config: {
-      rateLimit: {
-        max: 2,
-        timeWindow: 1000,
-        groupId: 'group2'
-      }
-    }
-  }, async (req, reply) => 'hello from route 2!')
+  fastify.get(
+    "/route2",
+    {
+      config: {
+        rateLimit: {
+          max: 2,
+          timeWindow: 500,
+          groupId: "group2",
+        },
+      },
+    },
+    async (req, reply) => "hello from route 2!"
+  );
 
-  let res
+  let res;
 
   // Test Route 1
-  res = await fastify.inject('/route1')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  res = await fastify.inject({ url: "/route1", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
 
-  res = await fastify.inject('/route1')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  res = await fastify.inject({ url: "/route1", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
 
-  res = await fastify.inject('/route1')
-  t.assert.deepStrictEqual(res.statusCode, 429)
-  await sleep(10)
-  t.assert.deepStrictEqual(
-    res.headers['content-type'],
-    'application/json; charset=utf-8'
-  )
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
-  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
-  await sleep(10)
-  t.assert.deepStrictEqual(
+  res = await fastify.inject({ url: "/route1", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 429);
+  assert.deepStrictEqual(
+    res.headers["content-type"],
+    "application/json; charset=utf-8"
+  );
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
+  assert.deepStrictEqual(res.headers["retry-after"], "1");
+  assert.deepStrictEqual(
     {
       statusCode: 429,
-      error: 'Too Many Requests',
-      message: 'Rate limit exceeded, retry in 1 second'
+      error: "Too Many Requests",
+      message: "Rate limit exceeded, retry in 500 ms",
     },
     JSON.parse(res.payload)
-  )
+  );
 
   // Test Route 2
-  res = await fastify.inject('/route2')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  res = await fastify.inject({ url: "/route2", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
 
-  res = await fastify.inject('/route2')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  res = await fastify.inject({ url: "/route2", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
 
-  res = await fastify.inject('/route2')
-  t.assert.deepStrictEqual(res.statusCode, 429)
-  t.assert.deepStrictEqual(
-    res.headers['content-type'],
-    'application/json; charset=utf-8'
-  )
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
-  t.assert.deepStrictEqual(res.headers['retry-after'], '1')
-  t.assert.deepStrictEqual(
+  res = await fastify.inject({ url: "/route2", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 429);
+  assert.deepStrictEqual(
+    res.headers["content-type"],
+    "application/json; charset=utf-8"
+  );
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
+  assert.deepStrictEqual(res.headers["retry-after"], "1");
+  assert.deepStrictEqual(
     {
       statusCode: 429,
-      error: 'Too Many Requests',
-      message: 'Rate limit exceeded, retry in 1 second'
+      error: "Too Many Requests",
+      message: "Rate limit exceeded, retry in 500 ms",
     },
     JSON.parse(res.payload)
-  )
+  );
 
   // Wait for the window to reset
-  clock.tick(1100)
+  await sleep(1000);
 
   // After reset, Route 1 should succeed again
-  res = await fastify.inject('/route1')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  res = await fastify.inject({ url: "/route1", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
 
   // Route 2 should also succeed after the reset
-  res = await fastify.inject('/route2')
-  t.assert.deepStrictEqual(res.statusCode, 200)
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
-  t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+  res = await fastify.inject({ url: "/route2", method: "GET" });
+  assert.deepStrictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
+  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
 
-  clock.reset()
-})
+});
 
-test('Invalid groupId type', async (t) => {
-  t.plan(1)
-  const fastify = Fastify()
+test("Invalid groupId type", async (t) => {
+  const fastify = Fastify();
 
   // Register rate limit plugin with a route having an invalid groupId
-  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
-
-  fastify.get('/invalidGroupId', {
-    config: {
-      rateLimit: {
-        max: 2,
-        timeWindow: 1000,
-        groupId: 123 // Invalid groupId type
-      }
-    }
-  }, async (req, reply) => 'hello with invalid groupId!')
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 });
 
   try {
-    await fastify.inject('/invalidGroupId')
-    t.fail('should throw')
+    fastify.get(
+      "/invalidGroupId",
+      {
+        config: {
+          rateLimit: {
+            max: 2,
+            timeWindow: 1000,
+            groupId: 123, // Invalid groupId type
+          },
+        },
+      },
+      async (req, reply) => "hello with invalid groupId!"
+    );
+    assert.fail("should throw");
+    console.log("HER")
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, 'groupId must be a string')
+    assert.deepStrictEqual(err.message, "groupId must be a string");
   }
-})
+});

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -1,148 +1,146 @@
-"use strict";
-const { test, mock } = require("node:test");
-const assert = require("assert");
-const Fastify = require("fastify");
-const rateLimit = require("../index");
+'use strict'
+const { test } = require('node:test')
+const assert = require('assert')
+const Fastify = require('fastify')
+const rateLimit = require('../index')
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
-
-test("With multiple routes and custom groupId", async (t) => {
-  const fastify = Fastify();
+test('With multiple routes and custom groupId', async (t) => {
+  const fastify = Fastify()
 
   // Register rate limit plugin
-  await fastify.register(rateLimit, { max: 2, timeWindow: 500 });
+  await fastify.register(rateLimit, { max: 2, timeWindow: 500 })
 
   // Route 1 with groupId 'group1'
   fastify.get(
-    "/route1",
+    '/route1',
     {
       config: {
         rateLimit: {
           max: 2,
           timeWindow: 500,
-          groupId: "group1",
-        },
-      },
+          groupId: 'group1'
+        }
+      }
     },
-    async (req, reply) => "hello from route 1!"
-  );
+    async (req, reply) => 'hello from route 1!'
+  )
 
   // Route 2 with groupId 'group2'
   fastify.get(
-    "/route2",
+    '/route2',
     {
       config: {
         rateLimit: {
           max: 2,
           timeWindow: 500,
-          groupId: "group2",
-        },
-      },
+          groupId: 'group2'
+        }
+      }
     },
-    async (req, reply) => "hello from route 2!"
-  );
+    async (req, reply) => 'hello from route 2!'
+  )
 
-  let res;
+  let res
 
   // Test Route 1
-  res = await fastify.inject({ url: "/route1", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
+  res = await fastify.inject({ url: '/route1', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
-  res = await fastify.inject({ url: "/route1", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
+  res = await fastify.inject({ url: '/route1', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
-  res = await fastify.inject({ url: "/route1", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 429);
+  res = await fastify.inject({ url: '/route1', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 429)
   assert.deepStrictEqual(
-    res.headers["content-type"],
-    "application/json; charset=utf-8"
-  );
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
-  assert.deepStrictEqual(res.headers["retry-after"], "1");
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  assert.deepStrictEqual(res.headers['retry-after'], '1')
   assert.deepStrictEqual(
     {
       statusCode: 429,
-      error: "Too Many Requests",
-      message: "Rate limit exceeded, retry in 500 ms",
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 500 ms'
     },
     JSON.parse(res.payload)
-  );
+  )
 
   // Test Route 2
-  res = await fastify.inject({ url: "/route2", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
+  res = await fastify.inject({ url: '/route2', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
-  res = await fastify.inject({ url: "/route2", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
+  res = await fastify.inject({ url: '/route2', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
 
-  res = await fastify.inject({ url: "/route2", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 429);
+  res = await fastify.inject({ url: '/route2', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 429)
   assert.deepStrictEqual(
-    res.headers["content-type"],
-    "application/json; charset=utf-8"
-  );
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "0");
-  assert.deepStrictEqual(res.headers["retry-after"], "1");
+    res.headers['content-type'],
+    'application/json; charset=utf-8'
+  )
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+  assert.deepStrictEqual(res.headers['retry-after'], '1')
   assert.deepStrictEqual(
     {
       statusCode: 429,
-      error: "Too Many Requests",
-      message: "Rate limit exceeded, retry in 500 ms",
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded, retry in 500 ms'
     },
     JSON.parse(res.payload)
-  );
+  )
 
   // Wait for the window to reset
-  await sleep(1000);
+  await sleep(1000)
 
   // After reset, Route 1 should succeed again
-  res = await fastify.inject({ url: "/route1", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
+  res = await fastify.inject({ url: '/route1', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
 
   // Route 2 should also succeed after the reset
-  res = await fastify.inject({ url: "/route2", method: "GET" });
-  assert.deepStrictEqual(res.statusCode, 200);
-  assert.deepStrictEqual(res.headers["x-ratelimit-limit"], "2");
-  assert.deepStrictEqual(res.headers["x-ratelimit-remaining"], "1");
+  res = await fastify.inject({ url: '/route2', method: 'GET' })
+  assert.deepStrictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+  assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+})
 
-});
-
-test("Invalid groupId type", async (t) => {
-  const fastify = Fastify();
+test('Invalid groupId type', async (t) => {
+  const fastify = Fastify()
 
   // Register rate limit plugin with a route having an invalid groupId
-  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 });
+  await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
 
   try {
     fastify.get(
-      "/invalidGroupId",
+      '/invalidGroupId',
       {
         config: {
           rateLimit: {
             max: 2,
             timeWindow: 1000,
-            groupId: 123, // Invalid groupId type
-          },
-        },
+            groupId: 123 // Invalid groupId type
+          }
+        }
       },
-      async (req, reply) => "hello with invalid groupId!"
-    );
-    assert.fail("should throw");
-    console.log("HER")
+      async (req, reply) => 'hello with invalid groupId!'
+    )
+    assert.fail('should throw')
+    console.log('HER')
   } catch (err) {
-    assert.deepStrictEqual(err.message, "groupId must be a string");
+    assert.deepStrictEqual(err.message, 'groupId must be a string')
   }
-});
+})

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -5,7 +5,6 @@ const rateLimit = require('../index')
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 test('With multiple routes and custom groupId', async (t) => {
-  t.plan(22)
   const clock = mock.timers
   clock.enable(0)
   const fastify = Fastify()
@@ -134,8 +133,8 @@ test('Invalid groupId type', async (t) => {
 
   try {
     await fastify.inject('/invalidGroupId')
-    t.fail('Expected an error to be thrown')
+    t.fail('should throw')
   } catch (err) {
-    t.assert(err.message.includes('groupId must be a string'))
+    t.assert.deepStrictEqual(err.message, ('groupId must be a string'))
   }
 })

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -9,7 +9,7 @@ test('With multiple routes and custom groupId', async (t) => {
   const clock = mock.timers
   clock.enable(0)
   const fastify = Fastify()
-  
+
   // Register rate limit plugin
   await fastify.register(rateLimit, { max: 2, timeWindow: 1000 })
 
@@ -50,6 +50,7 @@ test('With multiple routes and custom groupId', async (t) => {
 
   res = await fastify.inject('/route1')
   t.assert.deepStrictEqual(res.statusCode, 429)
+  await sleep(10)
   t.assert.deepStrictEqual(
     res.headers['content-type'],
     'application/json; charset=utf-8'
@@ -57,6 +58,7 @@ test('With multiple routes and custom groupId', async (t) => {
   t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
   t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
   t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+  await sleep(10)
   t.assert.deepStrictEqual(
     {
       statusCode: 429,


### PR DESCRIPTION
This PR adds the capability to group various routes and have a common rate limit for them.
#369

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)