### PR TITLE
perf: reduce optional chaining usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,19 +138,18 @@ async function fastifyRateLimit (fastify, settings) {
   }
 
   fastify.addHook('onRoute', (routeOptions) => {
-    if (routeOptions.config?.rateLimit !== undefined) {
+    if (routeOptions.config?.rateLimit != null) {
       if (typeof routeOptions.config.rateLimit === 'object') {
         const newPluginComponent = Object.create(pluginComponent)
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
         newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
 
-        if (routeOptions?.config?.rateLimit?.groupId) {
-          const groupId = routeOptions.config.rateLimit.groupId
-          if (typeof groupId === 'string') {
-            addRouteRateHook(pluginComponent, globalParams, routeOptions)
-          } else {
+        if (routeOptions.config.rateLimit.groupId) {
+          if (typeof routeOptions.config.rateLimit.groupId !== 'string') {
             throw new Error('groupId must be a string')
           }
+
+          addRouteRateHook(pluginComponent, globalParams, routeOptions)
         } else {
           addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
         }
@@ -219,7 +218,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     // Retrieve the key from the generator (the global one or the one defined in the endpoint)
     let key = await params.keyGenerator(req)
-    const groupId = req?.routeOptions?.config?.rateLimit?.groupId
+    const groupId = req.routeOptions.config?.rateLimit?.groupId
 
     if (groupId) {
       key += groupId


### PR DESCRIPTION
From the [V8 blog](https://v8.dev/features/optional-chaining):

> Still, be considerate about using more than one optional chaining operator in a single chain. If a value is guaranteed to not be nullish, then using ?. to access properties on it is discouraged.

It adds more bytecode to each property access