### PR TITLE
fix: apply merged params when custom route config is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,15 +145,7 @@ async function fastifyRateLimit (fastify, settings) {
         const mergedRateLimitParams = mergeParams(globalParams, routeOptions.config.rateLimit, { routeInfo: routeOptions })
         newPluginComponent.store = pluginComponent.store.child(mergedRateLimitParams)
 
-        if (routeOptions.config.rateLimit.groupId) {
-          if (typeof routeOptions.config.rateLimit.groupId !== 'string') {
-            throw new Error('groupId must be a string')
-          }
-
-          addRouteRateHook(pluginComponent, globalParams, routeOptions)
-        } else {
-          addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
-        }
+        addRouteRateHook(newPluginComponent, mergedRateLimitParams, routeOptions)
       } else if (routeOptions.config.rateLimit !== false) {
         throw new Error('Unknown value for route rate-limit configuration')
       }
@@ -185,6 +177,10 @@ function mergeParams (...params) {
     result.ban = Math.trunc(result.ban)
   } else {
     result.ban = -1
+  }
+
+  if (result.groupId !== undefined && typeof result.groupId !== 'string') {
+    throw new Error('groupId must be a string')
   }
 
   return result

--- a/test/group-rate-limit.test.js
+++ b/test/group-rate-limit.test.js
@@ -140,7 +140,7 @@ test('With multiple routes and custom groupId', async (t) => {
       config: {
         rateLimit: {
           max: 2,
-          timeWindow: 500,
+          timeWindow: 1000,
           groupId: 'group2'
         }
       }
@@ -203,7 +203,7 @@ test('With multiple routes and custom groupId', async (t) => {
     {
       statusCode: 429,
       error: 'Too Many Requests',
-      message: 'Rate limit exceeded, retry in 500 ms'
+      message: 'Rate limit exceeded, retry in 1 second'
     },
     JSON.parse(res.payload)
   )


### PR DESCRIPTION
We cannot use the global params when groupId is used, it just breaks the route configs — I think this was an oversight in the original PR, it had tests that tested custom route configs, but they were actually not correct as they didn't test different values

`groupId` should **only** affect the request id generation