### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -5,7 +5,7 @@ import fastify, {
   RequestGenericInterface,
   RouteOptions
 } from 'fastify'
-import * as http2 from 'http2'
+import * as http2 from 'node:http2'
 import IORedis from 'ioredis'
 import pino from 'pino'
 import fastifyRateLimit, {


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.