### PR TITLE
Add function to manually check rate limit #346 #408

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,16 +125,17 @@ async function fastifyRateLimit (fastify, settings) {
 
   fastify.decorateRequest(pluginComponent.rateLimitRan, false)
 
+  if (!fastify.hasDecorator('createRateLimit')) {
+    fastify.decorate('createRateLimit', (options) => {
+      const args = generateLimiterArguments(pluginComponent, globalParams, options)
+      return (req) => applyRateLimit(...args, req)
+    })
+  }
+
   if (!fastify.hasDecorator('rateLimit')) {
     fastify.decorate('rateLimit', (options) => {
-      if (typeof options === 'object') {
-        const newPluginComponent = Object.create(pluginComponent)
-        const mergedRateLimitParams = mergeParams(globalParams, options, { routeInfo: {} })
-        newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
-        return rateLimitRequestHandler(newPluginComponent, mergedRateLimitParams)
-      }
-
-      return rateLimitRequestHandler(pluginComponent, globalParams)
+      const args = generateLimiterArguments(pluginComponent, globalParams, options)
+      return rateLimitRequestHandler(...args)
     })
   }
 
@@ -186,6 +187,17 @@ function mergeParams (...params) {
   return result
 }
 
+function generateLimiterArguments (pluginComponent, globalParams, options) {
+  if (typeof options === 'object') {
+    const newPluginComponent = Object.create(pluginComponent)
+    const mergedRateLimitParams = mergeParams(globalParams, options, { routeInfo: {} })
+    newPluginComponent.store = newPluginComponent.store.child(mergedRateLimitParams)
+    return [newPluginComponent, mergedRateLimitParams]
+  }
+
+  return [pluginComponent, globalParams]
+}
+
 function addRouteRateHook (pluginComponent, params, routeOptions) {
   const hook = params.hook
   const hookHandler = rateLimitRequestHandler(pluginComponent, params)
@@ -198,8 +210,71 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
   }
 }
 
+async function applyRateLimit (pluginComponent, params, req) {
+  const { store } = pluginComponent
+
+  // Retrieve the key from the generator (the global one or the one defined in the endpoint)
+  let key = await params.keyGenerator(req)
+  const groupId = req.routeOptions.config?.rateLimit?.groupId
+  if (groupId) {
+    key += groupId
+  }
+
+  // Don't apply any rate limiting if in the allow list
+  if (params.allowList) {
+    if (typeof params.allowList === 'function') {
+      if (await params.allowList(req, key)) {
+        return {
+          isAllowed: true,
+          key
+        }
+      }
+    } else if (params.allowList.indexOf(key) !== -1) {
+      return {
+        isAllowed: true,
+        key
+      }
+    }
+  }
+
+  const max = typeof params.max === 'number' ? params.max : await params.max(req, key)
+  const timeWindow = typeof params.timeWindow === 'number' ? params.timeWindow : await params.timeWindow(req, key)
+  let current = 0
+  let ttl = 0
+  let ttlInSeconds = 0
+
+  // We increment the rate limit for the current request
+  try {
+    const res = await new Promise((resolve, reject) => {
+      store.incr(key, (err, res) => {
+        err ? reject(err) : resolve(res)
+      }, timeWindow, max)
+    })
+
+    current = res.current
+    ttl = res.ttl
+    ttlInSeconds = Math.ceil(res.ttl / 1000)
+  } catch (err) {
+    if (!params.skipOnError) {
+      throw err
+    }
+  }
+
+  return {
+    isAllowed: false,
+    key,
+    max,
+    timeWindow,
+    remaining: Math.max(0, max - current),
+    ttl,
+    ttlInSeconds,
+    isExceeded: current > max,
+    isBanned: params.ban !== -1 && current - max > params.ban
+  }
+}
+
 function rateLimitRequestHandler (pluginComponent, params) {
-  const { rateLimitRan, store } = pluginComponent
+  const { rateLimitRan } = pluginComponent
 
   return async (req, res) => {
     if (req[rateLimitRan]) {
@@ -208,50 +283,23 @@ function rateLimitRequestHandler (pluginComponent, params) {
 
     req[rateLimitRan] = true
 
-    // Retrieve the key from the generator (the global one or the one defined in the endpoint)
-    let key = await params.keyGenerator(req)
-    const groupId = req.routeOptions.config?.rateLimit?.groupId
-    if (groupId) {
-      key += groupId
+    const rateLimit = await applyRateLimit(pluginComponent, params, req)
+    if (rateLimit.isAllowed) {
+      return
     }
+    const {
+      key,
+      max,
+      remaining,
+      ttl,
+      ttlInSeconds,
+      isExceeded,
+      isBanned
+    } = rateLimit
 
-    // Don't apply any rate limiting if in the allow list
-    if (params.allowList) {
-      if (typeof params.allowList === 'function') {
-        if (await params.allowList(req, key)) {
-          return
-        }
-      } else if (params.allowList.indexOf(key) !== -1) {
-        return
-      }
-    }
-
-    const max = typeof params.max === 'number' ? params.max : await params.max(req, key)
-    const timeWindow = typeof params.timeWindow === 'number' ? params.timeWindow : await params.timeWindow(req, key)
-    let current = 0
-    let ttl = 0
-    let ttlInSeconds = 0
-
-    // We increment the rate limit for the current request
-    try {
-      const res = await new Promise((resolve, reject) => {
-        store.incr(key, (err, res) => {
-          err ? reject(err) : resolve(res)
-        }, timeWindow, max)
-      })
-
-      current = res.current
-      ttl = res.ttl
-      ttlInSeconds = Math.ceil(res.ttl / 1000)
-    } catch (err) {
-      if (!params.skipOnError) {
-        throw err
-      }
-    }
-
-    if (current <= max) {
+    if (!isExceeded) {
       if (params.addHeadersOnExceeding[params.labels.rateLimit]) { res.header(params.labels.rateLimit, max) }
-      if (params.addHeadersOnExceeding[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, max - current) }
+      if (params.addHeadersOnExceeding[params.labels.rateRemaining]) { res.header(params.labels.rateRemaining, remaining) }
       if (params.addHeadersOnExceeding[params.labels.rateReset]) { res.header(params.labels.rateReset, ttlInSeconds) }
 
       params.onExceeding(req, key)
@@ -274,7 +322,7 @@ function rateLimitRequestHandler (pluginComponent, params) {
       after: format(ttlInSeconds * 1000, true)
     }
 
-    if (params.ban !== -1 && current - max > params.ban) {
+    if (isBanned) {
       respCtx.statusCode = 403
       respCtx.ban = true
       params.onBanReach(req, key)

--- a/test/manual-rate-limit.test.js
+++ b/test/manual-rate-limit.test.js
@@ -25,7 +25,7 @@ describe('Manual check rate limit', () => {
       } else {
         t.assert.deepStrictEqual(limit.isExceeded, false)
       }
-      reply
+      return reply
         .code(limit.isExceeded ? 429 : 200)
         .header('x-ratelimit-limit', limit.max)
         .header('x-ratelimit-remaining', limit.remaining)

--- a/test/manual-rate-limit.test.js
+++ b/test/manual-rate-limit.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const { describe, test, mock } = require('node:test')
+const Fastify = require('fastify')
+const { fastifyRateLimit } = require('../index')
+
+describe('Manual check rate limit', () => {
+  test('Basic limit checks', async (t) => {
+    t.plan(13)
+    const clock = mock.timers
+    clock.enable(0)
+    const fastify = Fastify()
+    await fastify.register(fastifyRateLimit, { global: false })
+
+    const checkRateLimit = fastify.createRateLimit({ max: 2, timeWindow: 1000 })
+
+    fastify.get('/', async (req, reply) => {
+      const limit = await checkRateLimit(req)
+      const iteration = req.query.request
+      console.log('req', req.query.request)
+      console.log('limit', limit)
+      t.assert.deepStrictEqual(limit.isAllowed, false)
+      if (iteration === '3') {
+        t.assert.deepStrictEqual(limit.isExceeded, true)
+      } else {
+        t.assert.deepStrictEqual(limit.isExceeded, false)
+      }
+      reply
+        .code(limit.isExceeded ? 429 : 200)
+        .header('x-ratelimit-limit', limit.max)
+        .header('x-ratelimit-remaining', limit.remaining)
+        .header('x-ratelimit-reset', limit.reset)
+        .send('hello!')
+    })
+
+    let res
+
+    res = await fastify.inject('/?request=1')
+
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+
+    res = await fastify.inject('/?request=2')
+
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+
+    res = await fastify.inject('/?request=3')
+
+    t.assert.deepStrictEqual(res.statusCode, 429)
+
+    clock.reset()
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,23 @@ import {
 
 declare module 'fastify' {
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
+    createRateLimit(options?: fastifyRateLimit.CreateRateLimitOptions): (req: FastifyRequest) => Promise<
+      | {
+        isAllowed: true;
+        key: string;
+      }
+      | {
+        isAllowed: false;
+        key: string;
+        max: number;
+        timeWindow: number;
+        remaining: number;
+        ttl: number;
+        ttlInSeconds: number
+        isExceeded: boolean
+        isBanned: boolean
+      }
+    >
     rateLimit<
       RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
       ContextConfig = ContextConfigDefault,
@@ -89,13 +106,9 @@ declare namespace fastifyRateLimit {
     'ratelimit-reset'?: boolean;
   }
 
-  export type RateLimitHook =
-    | 'onRequest'
-    | 'preParsing'
-    | 'preValidation'
-    | 'preHandler'
-
-  export interface RateLimitOptions {
+  export interface CreateRateLimitOptions {
+    store?: FastifyRateLimitStoreCtor;
+    skipOnError?: boolean;
     max?:
       | number
       | ((req: FastifyRequest, key: string) => number)
@@ -105,19 +118,26 @@ declare namespace fastifyRateLimit {
       | string
       | ((req: FastifyRequest, key: string) => number)
       | ((req: FastifyRequest, key: string) => Promise<number>);
-    hook?: RateLimitHook;
-    cache?: number;
-    store?: FastifyRateLimitStoreCtor;
     /**
      * @deprecated Use `allowList` property
      */
     whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);
     allowList?: string[] | ((req: FastifyRequest, key: string) => boolean | Promise<boolean>);
-    continueExceeding?: boolean;
-    skipOnError?: boolean;
-    ban?: number;
-    onBanReach?: (req: FastifyRequest, key: string) => void;
     keyGenerator?: (req: FastifyRequest) => string | number | Promise<string | number>;
+    ban?: number;
+  }
+
+  export type RateLimitHook =
+    | 'onRequest'
+    | 'preParsing'
+    | 'preValidation'
+    | 'preHandler'
+
+  export interface RateLimitOptions extends CreateRateLimitOptions {
+    hook?: RateLimitHook;
+    cache?: number;
+    continueExceeding?: boolean;
+    onBanReach?: (req: FastifyRequest, key: string) => void;
     groupId?: string;
     errorResponseBuilder?: (
       req: FastifyRequest,
@@ -127,7 +147,6 @@ declare namespace fastifyRateLimit {
     onExceeding?: (req: FastifyRequest, key: string) => void;
     onExceeded?: (req: FastifyRequest, key: string) => void;
     exponentialBackoff?: boolean;
-
   }
 
   export interface RateLimitPluginOptions extends RateLimitOptions {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,7 +12,8 @@ import fastifyRateLimit, {
   errorResponseBuilderContext,
   FastifyRateLimitOptions,
   FastifyRateLimitStore,
-  RateLimitPluginOptions
+  RateLimitPluginOptions,
+  CreateRateLimitOptions,
 } from '..'
 import { expectAssignable, expectType } from 'tsd'
 
@@ -203,6 +204,26 @@ expectAssignable<errorResponseBuilderContext>({
   after: '123',
   max: 1000,
   ttl: 123
+})
+
+const options10: CreateRateLimitOptions = {
+  max: 0,
+  timeWindow: 5000,
+  allowList: ['127.0.0.1'],
+  skipOnError: true,
+  ban: 10,
+  keyGenerator: (req: FastifyRequest<RequestGenericInterface>) => req.ip,
+}
+
+const appForCreateRateLimit = fastify()
+appForCreateRateLimit.register(fastifyRateLimit, { global: false })
+const checkRateLimit = appForCreateRateLimit.createRateLimit(options10)
+appForCreateRateLimit.route({
+  method: 'GET',
+  url: '/',
+  handler: async (req, reply) => {
+    await checkRateLimit(req)
+  },
 })
 
 const appWithCustomLogger = fastify({


### PR DESCRIPTION
This is the updated PR (as I did not have access to the original PR) copy of [392](https://github.com/fastify/fastify-rate-limit/pull/392). It is a copy with an added test case on work done by @Charioteer and uses the latest master. I did not change any code. Just did some testing and added a unit test case.

The reason for finishing up the PR is issue no [408](https://github.com/fastify/fastify-rate-limit/issues/408). I'm copying the rest of the description here written by  @Charioteer so everything stays in one place. Feel free to close if you can provide me access to the original branch to make the change & wrap it up.

I can add the documentation given if this PR looks good to the contributors.

> From @Charioteer :

Following on from issue #346 and my [comment](https://github.com/fastify/fastify-rate-limit/issues/346#issuecomment-2331639190), I finally had some spare time to implement a draft version of my idea as suggested by @mcollina. I realized that any store (child) instance receives all the `options` provided to `fastify.rateLimit` when it is constructed, which is why I had to adjust my initial idea and come up with a slightly different solution.

Thanks and cheers Patrick

# How to Use
```ts
import Fastify from "fastify";
import { fastifyRateLimit } from "@fastify/rate-limit";

const fastify = Fastify();

await fastify.register(fastifyRateLimit, {
  global: false,
  max: 10,
  timeWindow: "10 seconds",
});

const checkRateLimit = fastify.createRateLimit(); // this will use the global options provided to fastifyRateLimit

fastify.get("/", async (request, reply) ={
  const limit = await checkRateLimit(request);

  if(!limit.isAllowed && limit.isExceeded) {
    return reply.code(429).send("Limit exceeded");
  }

  return reply.send("Hello world");
});


const checkCustomRateLimit = fastify.createRateLimit({ max: 100 }); // max provided to override global options

fastify.get("/custom", async (request, reply) ={
  const limit = await checkCustomRateLimit(request);

  if(!limit.isAllowed && limit.isExceeded) {
    return reply.code(429).send("Limit exceeded");
  }

  return reply.send("Hello world");
});
```

#### Checklist
* [x]  run `npm run test` and `npm run benchmark`
* [x]  tests and/or benchmarks are included
* [ ]  documentation is changed or added
* [x]  commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
  and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)



