### PR TITLE
perf: refactor redis script

### DIFF
--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -4,9 +4,9 @@ const lua = `
   -- Key to operate on
   local key = KEYS[1]
   -- Time window for the TTL
-  local timeWindow = ARGV[1]
+  local timeWindow = tonumber(ARGV[1])
   -- Max requests
-  local max = ARGV[2]
+  local max = tonumber(ARGV[2])
   -- Flag to determine if TTL should be reset after exceeding
   local continueExceeding = ARGV[3] == 'true'
   --Flag to determine if exponential backoff should be applied
@@ -18,27 +18,17 @@ const lua = `
   -- Increment the key's value
   local current = redis.call('INCR', key)
 
-  -- If the key is new then set its TTL
-  if current == 1 then
+  if current == 1 or (continueExceeding and current > max) then
     redis.call('PEXPIRE', key, timeWindow)
-    return {current, timeWindow}
-  end
-
-  -- Get ttl of the key
-  local ttl = redis.call('PTTL', key)
-
-  -- If continueExceeding is enabled and the key's value has exceeded the max value then set its TTL
-  if continueExceeding and current > max then
-    ttl = timeWindow
-  -- If exponentialBackoff is enabled and the key's value has exceeded the max value then set its TTL
   elseif exponentialBackoff and current > max then
     local backoffExponent = current - max - 1
-    ttl = math.min(timeWindow * (2.0 ^ backoffExponent), MAX_SAFE_INTEGER)
+    timeWindow = math.min(timeWindow * (2 ^ backoffExponent), MAX_SAFE_INTEGER)
+    redis.call('PEXPIRE', key, timeWindow)
+  else
+    timeWindow = redis.call('PTTL', key)
   end
 
-  redis.call('PEXPIRE', key, ttl)
-
-  return {current, ttl}
+  return {current, timeWindow}
 `
 
 function RedisStore (continueExceeding, exponentialBackoff, redis, key = 'fastify-rate-limit-') {


### PR DESCRIPTION
- refactors redis script
- reduces `redis` calls to 2 per invocation while before we'd do 3 calls for each new key
- adds exponential backoff tests for Redis