### PR TITLE
fix: add missing types for store.incr parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,7 @@ function CustomStore (options) {
   this.current = 0
 }
 
-CustomStore.prototype.incr = function (key, cb) {
-  const timeWindow = this.options.timeWindow
+CustomStore.prototype.incr = function (key, cb, timeWindow, max) {
   this.current++
   cb(null, { current: this.current, ttl: timeWindow - (this.current * 1000) })
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,7 +74,9 @@ declare namespace fastifyRateLimit {
       callback: (
         error: Error | null,
         result?: { current: number; ttl: number }
-      ) => void
+      ) => void,
+      timeWindow: number,
+      max: number
     ): void;
     child(
       routeOptions: RouteOptions & { path: string; prefix: string }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -29,7 +29,9 @@ class CustomStore implements FastifyRateLimitStore {
     _callback: (
       error: Error | null,
       result?: { current: number; ttl: number }
-    ) => void
+    ) => void,
+    _timeWindow: number,
+    _max: number
   ) {}
 
   child (_routeOptions: RouteOptions & { path: string; prefix: string }) {


### PR DESCRIPTION
Added the missing `timeWindow` and `max` parameters to the `incr` method's types.

This method is only being called here, where these parameters can be seen:

https://github.com/fastify/fastify-rate-limit/blob/843aca32546b2316e43e888064c9c94ebb1dafd9/index.js#L250-L252

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
