### PR TITLE
chore: removed types deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ async function fastifyRateLimit (fastify, settings) {
   }
 
   globalParams.hook = settings.hook || defaultHook
-  globalParams.allowList = settings.allowList || settings.whitelist || null
+  globalParams.allowList = settings.allowList || null
   globalParams.ban = Number.isFinite(settings.ban) && settings.ban >= 0 ? Math.trunc(settings.ban) : -1
   globalParams.onBanReach = typeof settings.onBanReach === 'function' ? settings.onBanReach : defaultOnFn
   globalParams.onExceeding = typeof settings.onExceeding === 'function' ? settings.onExceeding : defaultOnFn

--- a/test/global-rate-limit.test.js
+++ b/test/global-rate-limit.test.js
@@ -249,13 +249,13 @@ test('With ips allowList, not allowed ips should result in rate limiting', async
   t.assert.deepStrictEqual(res.statusCode, 429)
 })
 
-test('With ips whitelist', async (t) => {
+test('With ips allowList', async (t) => {
   t.plan(3)
   const fastify = Fastify()
   await fastify.register(rateLimit, {
     max: 2,
     timeWindow: '2s',
-    whitelist: ['127.0.0.1']
+    allowList: ['127.0.0.1']
   })
 
   fastify.get('/', async () => 'hello!')

--- a/test/route-rate-limit.test.js
+++ b/test/route-rate-limit.test.js
@@ -1201,13 +1201,13 @@ test('Allow multiple different rate limiter registrations', async (t) => {
   await fastify.register(rateLimit, {
     max: 1,
     timeWindow: 1000,
-    whitelist: (req) => req.url !== '/test'
+    allowList: (req) => req.url !== '/test'
   })
 
   await fastify.register(rateLimit, {
     max: 1,
     timeWindow: 1000,
-    whitelist: (req) => req.url === '/test'
+    allowList: (req) => req.url === '/test'
   })
 
   fastify.get('/', async () => 'hello!')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -121,10 +121,6 @@ declare namespace fastifyRateLimit {
       | string
       | ((req: FastifyRequest, key: string) => number)
       | ((req: FastifyRequest, key: string) => Promise<number>);
-    /**
-    * @deprecated Use `allowList` property
-    */
-    whitelist?: string[] | ((req: FastifyRequest, key: string) => boolean);
     allowList?: string[] | ((req: FastifyRequest, key: string) => boolean | Promise<boolean>);
     keyGenerator?: (req: FastifyRequest) => string | number | Promise<string | number>;
     ban?: number;


### PR DESCRIPTION
Proposals:

- `index.js`: remove `settings.whitelist`
- `types/index.d.ts`: remove `@deprecated` `whitelist` property, keep `allowList`
- `test/global-rate-limit.test.js`: update test descriptions and options
- `test/route-rate-limit.test.js`: update `whitelist` → `allowList` in fixtures

Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274