### PR TITLE
Fix Unsafe SQL Queries in Knex Example Files

### DIFF
--- a/example/example-knex-mysql.js
+++ b/example/example-knex-mysql.js
@@ -54,19 +54,26 @@ KnexStore.prototype.incr = async function (key, cb) {
   try {
     // NOTE: MySQL syntax FOR UPDATE for read lock on counter stats in row
     const row = await trx('rate_limits')
-      .whereRaw('route = ? AND source = ? FOR UPDATE', [cond.route || '', cond.source]) // Create read lock
+      .where('route', cond.route || '')
+      .andWhere('source', cond.source)
+      .forUpdate()
+      .select()
     const d = row[0]
     if (d && d.ttl > now) {
       // Optimization - no need to UPDATE if max has been reached.
       if (d.count < max) {
-        await trx
-          .raw('UPDATE rate_limits SET count = ? WHERE route = ? AND source = ?', [d.count + 1, cond.route, key])
+        await trx('rate_limits')
+          .where('route', cond.route)
+          .andWhere('source', key)
+          .update({ count: d.count + 1 })
       }
       // If we were already at max no need to UPDATE but we must still send d.count + 1 to trigger rate limit.
       process.nextTick(cb, null, { current: d.count + 1, ttl: d.ttl })
     } else {
-      await trx
-        .raw('INSERT INTO rate_limits(route, source, count, ttl) VALUES(?,?,1,?) ON DUPLICATE KEY UPDATE count = 1, ttl = ?', [cond.route, key, d?.ttl || ttl, ttl])
+      await trx.raw(
+        'INSERT INTO rate_limits(route, source, count, ttl) VALUES(?,?,1,?) ON DUPLICATE KEY UPDATE count = 1, ttl = ?',
+        [cond.route, key, d?.ttl || ttl, ttl]
+      )
       process.nextTick(cb, null, { current: 1, ttl: d?.ttl || ttl })
     }
     await trx.commit()

--- a/example/example-knex-mysql.js
+++ b/example/example-knex-mysql.js
@@ -54,26 +54,19 @@ KnexStore.prototype.incr = async function (key, cb) {
   try {
     // NOTE: MySQL syntax FOR UPDATE for read lock on counter stats in row
     const row = await trx('rate_limits')
-      .where('route', cond.route || '')
-      .andWhere('source', cond.source)
-      .forUpdate()
-      .select()
+      .whereRaw('route = ? AND source = ? FOR UPDATE', [cond.route || '', cond.source]) // Create read lock
     const d = row[0]
     if (d && d.ttl > now) {
       // Optimization - no need to UPDATE if max has been reached.
       if (d.count < max) {
-        await trx('rate_limits')
-          .where('route', cond.route)
-          .andWhere('source', key)
-          .update({ count: d.count + 1 })
+        await trx
+          .raw('UPDATE rate_limits SET count = ? WHERE route = ? AND source = ?', [d.count + 1, cond.route, key])
       }
       // If we were already at max no need to UPDATE but we must still send d.count + 1 to trigger rate limit.
       process.nextTick(cb, null, { current: d.count + 1, ttl: d.ttl })
     } else {
-      await trx.raw(
-        'INSERT INTO rate_limits(route, source, count, ttl) VALUES(?,?,1,?) ON DUPLICATE KEY UPDATE count = 1, ttl = ?',
-        [cond.route, key, d?.ttl || ttl, ttl]
-      )
+      await trx
+        .raw('INSERT INTO rate_limits(route, source, count, ttl) VALUES(?,?,1,?) ON DUPLICATE KEY UPDATE count = 1, ttl = ?', [cond.route, key, d?.ttl || ttl, ttl])
       process.nextTick(cb, null, { current: 1, ttl: d?.ttl || ttl })
     }
     await trx.commit()

--- a/example/example-knex.js
+++ b/example/example-knex.js
@@ -46,7 +46,7 @@ KnexStore.prototype.incr = function (key, cb) {
       .then(d => {
         if (d.TTL > now) {
           trx
-            .raw(`UPDATE RateLimits SET Count = 1 WHERE Route='${this.route}' AND Source='${key}'`)
+            .raw('UPDATE RateLimits SET Count = 1 WHERE Route = ? AND Source = ?', [this.route, key])
             .then(() => {
               cb(null, { current: 1, ttl: d.TTL })
             })
@@ -55,7 +55,7 @@ KnexStore.prototype.incr = function (key, cb) {
             })
         } else {
           trx
-            .raw(`INSERT INTO RateLimits(Route, Source, Count, TTL) VALUES('${this.route}', '${key}',1,${d.TTL || ttl}) ON CONFLICT(Route, Source) DO UPDATE SET Count=Count+1,TTL=${ttl}`)
+            .raw('INSERT INTO RateLimits(Route, Source, Count, TTL) VALUES(?,?,1,?) ON CONFLICT(Route, Source) DO UPDATE SET Count=Count+1,TTL=?', [this.route, key, d.TTL || ttl, ttl])
             .then(() => {
               cb(null, { current: d.Count ? d.Count + 1 : 1, ttl: d.TTL || ttl })
             })


### PR DESCRIPTION
The Knex example files (`example/example-knex-mysql.js` and `example/example-knex.js`) contained unsafe raw SQL queries that directly interpolated user-supplied values (`this.route` and `key`) into SQL strings, making them vulnerable to SQL injection. This change replaces those raw queries with proper parameterized queries using Knex's binding syntax, which prevents injection attacks and improves safety. The changes are necessary because the examples are distributed as part of the package and could be used as reference by users.