### PR TITLE
feat: add increment option to createRateLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ If `isAllowed` is `false` the object also contains these additional properties:
 - `isExceeded`: `true` if the limit was exceeded.
 - `isBanned`: `true` if the request was banned according to the `ban` option.
 
-The limiter function accepts an optional second argument `{ increment: boolean }`. When `increment` is `false`, the current rate limit status is returned **without consuming a request**. This is useful when a limit should only be enforced on certain outcomes (e.g. failed login attempts) while still checking the status before processing.
+The limiter function accepts an optional second argument `{ increment?: boolean }`. The `increment` flag defaults to `true`, so omitting the argument keeps the original behavior (the request is consumed). When `increment` is `false`, the current rate limit status is returned **without consuming a request**. This is useful when a limit should only be enforced on certain outcomes (e.g. failed login attempts) while still checking the status before processing.
 
 ```js
 const checkRateLimit = fastify.createRateLimit({ max: 5, timeWindow: '1 minute' });
@@ -539,6 +539,12 @@ fastify.post('/login', async (request, reply) => {
   return { ok: true };
 });
 ```
+
+A few things to keep in mind when using `{ increment: false }`:
+
+- **It is a non-mutating snapshot.** A peek never increments the counter, resets the window, or advances the `ban`/`continueExceeding`/`exponentialBackoff` side effects that a real request triggers. The returned `isExceeded`/`isBanned` therefore reflect the *current* counters, but a peek will not, by itself, escalate a ban or extend a backoff window.
+- **`ttl` reflects the store's current window.** With the Redis store, `ttl` is the raw server `PTTL` (the same value `incr` reports), so it can exceed the configured `timeWindow` when `continueExceeding`/`exponentialBackoff` has extended it.
+- **Custom stores must implement `read`.** The flag relies on a non-mutating `read(ip, cb, timeWindow, max)` method, which mirrors the `incr` signature. The built-in local and Redis stores provide it; a custom store that does not will throw a clear error when called with `{ increment: false }`.
 
 ### Examples of Custom Store
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,29 @@ If `isAllowed` is `false` the object also contains these additional properties:
 - `isExceeded`: `true` if the limit was exceeded.
 - `isBanned`: `true` if the request was banned according to the `ban` option.
 
+The limiter function accepts an optional second argument `{ increment: boolean }`. When `increment` is `false`, the current rate limit status is returned **without consuming a request**. This is useful when a limit should only be enforced on certain outcomes (e.g. failed login attempts) while still checking the status before processing.
+
+```js
+const checkRateLimit = fastify.createRateLimit({ max: 5, timeWindow: '1 minute' });
+
+fastify.post('/login', async (request, reply) => {
+  // Peek at the current status without consuming a request
+  const status = await checkRateLimit(request, { increment: false });
+  if (status.isExceeded) {
+    return reply.code(429).send({ error: 'Too many attempts' });
+  }
+
+  const success = await tryLogin(request.body);
+  if (!success) {
+    // Only consume a request when the login fails
+    await checkRateLimit(request);
+    return reply.code(401).send({ error: 'Invalid credentials' });
+  }
+
+  return { ok: true };
+});
+```
+
 ### Examples of Custom Store
 
 These examples show an overview of the `store` feature and you should take inspiration from it and tweak as you need:

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ async function fastifyRateLimit (fastify, settings) {
   if (!fastify.hasDecorator('createRateLimit')) {
     fastify.decorate('createRateLimit', (options) => {
       const args = createLimiterArgs(pluginComponent, globalParams, options)
-      return (req) => applyRateLimit.apply(this, args.concat(req))
+      return (req, callOptions) => applyRateLimit.apply(this, args.concat(req, callOptions))
     })
   }
 
@@ -210,7 +210,7 @@ function addRouteRateHook (pluginComponent, params, routeOptions) {
   }
 }
 
-async function applyRateLimit (pluginComponent, params, req) {
+async function applyRateLimit (pluginComponent, params, req, callOptions) {
   const { store } = pluginComponent
 
   // Retrieve the key from the generator (the global one or the one defined in the endpoint)
@@ -244,10 +244,10 @@ async function applyRateLimit (pluginComponent, params, req) {
   let ttl = 0
   let ttlInSeconds = 0
 
-  // We increment the rate limit for the current request
+  const storeMethod = callOptions?.increment === false ? 'read' : 'incr'
   try {
     const res = await new Promise((resolve, reject) => {
-      store.incr(key, (err, res) => {
+      store[storeMethod](key, (err, res) => {
         err ? reject(err) : resolve(res)
       }, timeWindow, max)
     })

--- a/index.js
+++ b/index.js
@@ -245,6 +245,14 @@ async function applyRateLimit (pluginComponent, params, req, callOptions) {
   let ttlInSeconds = 0
 
   const storeMethod = callOptions?.increment === false ? 'read' : 'incr'
+
+  // `{ increment: false }` requires the store to implement a non-mutating
+  // `read` method. Custom stores may not, so fail fast with a clear message
+  // instead of a cryptic "store[storeMethod] is not a function" TypeError.
+  if (storeMethod === 'read' && typeof store.read !== 'function') {
+    throw new Error('The configured rate-limit store does not implement a `read` method, which is required to use `{ increment: false }`')
+  }
+
   try {
     const res = await new Promise((resolve, reject) => {
       store[storeMethod](key, (err, res) => {

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -43,7 +43,25 @@ LocalStore.prototype.incr = function (ip, cb, timeWindow, max) {
   cb(null, current)
 }
 
-LocalStore.prototype.read = function (ip, cb, timeWindow) {
+/**
+ * Read the current rate-limit state for `ip` without mutating it.
+ *
+ * Stores expose `read` with the same argument contract as `incr`
+ * (`ip, cb, timeWindow, max`) so the two are interchangeable; an
+ * implementation may ignore the arguments it does not need (`max` here).
+ *
+ * `read` is a non-mutating snapshot: it never increments the counter, resets
+ * the window, or advances the `continueExceeding`/`exponentialBackoff`/`ban`
+ * side effects that `incr` applies. It mirrors `incr`'s window-expiry
+ * detection, so a peek and a real request agree on whether the window is
+ * still active.
+ *
+ * @param {string} ip
+ * @param {(err: Error | null, res: { current: number, ttl: number }) => void} cb
+ * @param {number} timeWindow
+ * @param {number} [max]
+ */
+LocalStore.prototype.read = function (ip, cb, timeWindow, max) {
   const nowInMs = Date.now()
   const current = this.lru.get(ip)
 

--- a/store/LocalStore.js
+++ b/store/LocalStore.js
@@ -43,6 +43,21 @@ LocalStore.prototype.incr = function (ip, cb, timeWindow, max) {
   cb(null, current)
 }
 
+LocalStore.prototype.read = function (ip, cb, timeWindow) {
+  const nowInMs = Date.now()
+  const current = this.lru.get(ip)
+
+  if (!current || current.iterationStartMs + timeWindow <= nowInMs) {
+    // Item doesn't exist or has expired: report a clean state without mutating
+    cb(null, { current: 0, ttl: 0 })
+    return
+  }
+
+  // Item is alive: report the current state without mutating
+  const ttl = timeWindow - (nowInMs - current.iterationStartMs)
+  cb(null, { current: current.current, ttl })
+}
+
 LocalStore.prototype.child = function (routeOptions) {
   return new LocalStore(routeOptions.continueExceeding, routeOptions.exponentialBackoff, routeOptions.cache)
 }

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -31,6 +31,28 @@ const lua = `
   return {current, timeWindow}
 `
 
+const luaRead = `
+  -- Key to operate on
+  local key = KEYS[1]
+
+  -- Read the counter without mutating it
+  local current = redis.call('GET', key)
+
+  if current == false then
+    -- Key doesn't exist: clean state
+    return {0, 0}
+  end
+
+  -- Read the remaining TTL in milliseconds
+  local ttl = redis.call('PTTL', key)
+  if ttl < 0 then
+    -- -2 (no key) or -1 (no expiry): report no active window
+    ttl = 0
+  end
+
+  return {tonumber(current), ttl}
+`
+
 function RedisStore (continueExceeding, exponentialBackoff, redis, key = 'fastify-rate-limit-') {
   this.continueExceeding = continueExceeding
   this.exponentialBackoff = exponentialBackoff
@@ -43,10 +65,23 @@ function RedisStore (continueExceeding, exponentialBackoff, redis, key = 'fastif
       lua
     })
   }
+
+  if (!this.redis.rateLimitRead) {
+    this.redis.defineCommand('rateLimitRead', {
+      numberOfKeys: 1,
+      lua: luaRead
+    })
+  }
 }
 
 RedisStore.prototype.incr = function (ip, cb, timeWindow, max) {
   this.redis.rateLimit(this.key + ip, timeWindow, max, this.continueExceeding, this.exponentialBackoff, (err, result) => {
+    err ? cb(err, null) : cb(null, { current: result[0], ttl: result[1] })
+  })
+}
+
+RedisStore.prototype.read = function (ip, cb) {
+  this.redis.rateLimitRead(this.key + ip, (err, result) => {
     err ? cb(err, null) : cb(null, { current: result[0], ttl: result[1] })
   })
 }

--- a/store/RedisStore.js
+++ b/store/RedisStore.js
@@ -38,7 +38,9 @@ const luaRead = `
   -- Read the counter without mutating it
   local current = redis.call('GET', key)
 
-  if current == false then
+  -- A missing key returns false from redis.call (and nil from redis.pcall);
+  -- "not current" covers both, so the clean-state branch is robust either way.
+  if not current then
     -- Key doesn't exist: clean state
     return {0, 0}
   end
@@ -80,7 +82,21 @@ RedisStore.prototype.incr = function (ip, cb, timeWindow, max) {
   })
 }
 
-RedisStore.prototype.read = function (ip, cb) {
+/**
+ * Read the current rate-limit state for `ip` without mutating it.
+ *
+ * Same argument contract as `incr` (`ip, cb, timeWindow, max`); the Redis
+ * implementation only needs the key, so `timeWindow`/`max` are ignored. The
+ * reported `ttl` is the raw server `PTTL` — the same source `incr` returns on
+ * its alive path — so it may exceed the configured `timeWindow` when
+ * `continueExceeding`/`exponentialBackoff` extended it.
+ *
+ * @param {string} ip
+ * @param {(err: Error | null, res: { current: number, ttl: number }) => void} cb
+ * @param {number} [timeWindow]
+ * @param {number} [max]
+ */
+RedisStore.prototype.read = function (ip, cb, timeWindow, max) {
   this.redis.rateLimitRead(this.key + ip, (err, result) => {
     err ? cb(err, null) : cb(null, { current: result[0], ttl: result[1] })
   })

--- a/test/create-rate-limit.test.js
+++ b/test/create-rate-limit.test.js
@@ -322,3 +322,149 @@ test('With { increment: false } it reads the state without consuming it', async 
 
   clock.reset()
 })
+
+test('With { increment: false } and continueExceeding the peek mirrors the active window', async t => {
+  t.plan(4)
+  const clock = mock.timers
+  clock.enable(0)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    max: 1,
+    timeWindow: 1000,
+    continueExceeding: true
+  })
+
+  const checkRateLimit = fastify.createRateLimit()
+  fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+  fastify.get('/consume', async (req) => checkRateLimit(req))
+
+  let res
+
+  await fastify.inject('/consume') // current = 1
+  clock.tick(100)
+  await fastify.inject('/consume') // current = 2 -> continueExceeding resets the window
+  clock.tick(100)
+
+  // Peek inside the active window: shows the exceeded state, does not reset it
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 1,
+    timeWindow: 1000,
+    remaining: 0,
+    ttl: 900,
+    ttlInSeconds: 1,
+    isExceeded: true,
+    isBanned: false
+  })
+
+  // Once the window elapses, the peek reports a clean state again (matching incr)
+  clock.tick(1000)
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 1,
+    timeWindow: 1000,
+    remaining: 1,
+    ttl: 0,
+    ttlInSeconds: 0,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  clock.reset()
+})
+
+test('With { increment: false } and exponentialBackoff the peek reports the base window without escalating it', async t => {
+  t.plan(4)
+  const clock = mock.timers
+  clock.enable(0)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    max: 1,
+    timeWindow: 1000,
+    exponentialBackoff: true
+  })
+
+  const checkRateLimit = fastify.createRateLimit()
+  fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+  fastify.get('/consume', async (req) => checkRateLimit(req))
+
+  let res
+
+  await fastify.inject('/consume') // current = 1
+  clock.tick(100)
+  await fastify.inject('/consume') // current = 2 -> backoff window doubles
+  clock.tick(100)
+  await fastify.inject('/consume') // current = 3 -> backoff window doubles again
+  clock.tick(100)
+
+  // Peek reports the current count and the base-window ttl, without escalating
+  // the backoff window the way a real (incrementing) request would.
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 1,
+    timeWindow: 1000,
+    remaining: 0,
+    ttl: 900,
+    ttlInSeconds: 1,
+    isExceeded: true,
+    isBanned: false
+  })
+
+  // Once the base window elapses, the peek reports a clean state
+  clock.tick(1000)
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 1,
+    timeWindow: 1000,
+    remaining: 1,
+    ttl: 0,
+    ttlInSeconds: 0,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  clock.reset()
+})
+
+test('With { increment: false } it throws a clear error when the store has no read method', async t => {
+  t.plan(2)
+
+  class NoReadStore {
+    incr (ip, cb, timeWindow) {
+      cb(null, { current: 1, ttl: timeWindow })
+    }
+
+    child () {
+      return this
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    max: 2,
+    timeWindow: 1000,
+    store: NoReadStore
+  })
+
+  const checkRateLimit = fastify.createRateLimit()
+  fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+
+  const res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 500)
+  t.assert.ok(res.json().message.includes('read'))
+})

--- a/test/create-rate-limit.test.js
+++ b/test/create-rate-limit.test.js
@@ -221,4 +221,104 @@ test('With allow list', async t => {
     isAllowed: true,
     key: '127.0.0.1'
   })
+
+  clock.reset()
+})
+
+test('With { increment: false } it reads the state without consuming it', async t => {
+  t.plan(10)
+  const clock = mock.timers
+  clock.enable(0)
+  const fastify = Fastify()
+  await fastify.register(rateLimit, {
+    global: false,
+    max: 2,
+    timeWindow: 1000
+  })
+
+  const checkRateLimit = fastify.createRateLimit()
+
+  fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+  fastify.get('/consume', async (req) => checkRateLimit(req))
+
+  let res
+
+  // Peek before any request: clean state, nothing consumed
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 2,
+    timeWindow: 1000,
+    remaining: 2,
+    ttl: 0,
+    ttlInSeconds: 0,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  // Consume one request
+  res = await fastify.inject('/consume')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 2,
+    timeWindow: 1000,
+    remaining: 1,
+    ttl: 1000,
+    ttlInSeconds: 1,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  // Peek again: reads the active window without consuming (remaining stays 1)
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 2,
+    timeWindow: 1000,
+    remaining: 1,
+    ttl: 1000,
+    ttlInSeconds: 1,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  // Consume again: now the limit is reached
+  res = await fastify.inject('/consume')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 2,
+    timeWindow: 1000,
+    remaining: 0,
+    ttl: 1000,
+    ttlInSeconds: 1,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  // After the window expires, peek reports a clean state again
+  clock.tick(1100)
+
+  res = await fastify.inject('/peek')
+  t.assert.deepStrictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(res.json(), {
+    isAllowed: false,
+    key: '127.0.0.1',
+    max: 2,
+    timeWindow: 1000,
+    remaining: 2,
+    ttl: 0,
+    ttlInSeconds: 0,
+    isExceeded: false,
+    isBanned: false
+  })
+
+  clock.reset()
 })

--- a/test/redis-rate-limit.test.js
+++ b/test/redis-rate-limit.test.js
@@ -428,6 +428,74 @@ describe('Global rate limit', () => {
     await redis.flushall()
     await redis.quit()
   })
+
+  test('With { increment: false } it reads the state without consuming it', async (t) => {
+    t.plan(5)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await redis.flushall()
+    await fastify.register(rateLimit, {
+      global: false,
+      max: 2,
+      timeWindow: 1000,
+      redis
+    })
+
+    const checkRateLimit = fastify.createRateLimit()
+
+    fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+    fastify.get('/consume', async (req) => checkRateLimit(req))
+
+    let res
+
+    // Peek before any request: clean state, nothing consumed
+    res = await fastify.inject('/peek')
+    t.assert.deepStrictEqual(res.json().remaining, 2)
+
+    // Consume one request
+    res = await fastify.inject('/consume')
+    t.assert.deepStrictEqual(res.json().remaining, 1)
+
+    // Peek again: reads the active window without consuming (remaining stays 1)
+    res = await fastify.inject('/peek')
+    t.assert.deepStrictEqual(res.json().remaining, 1)
+
+    // Consume again: the limit is now reached
+    res = await fastify.inject('/consume')
+    t.assert.deepStrictEqual(res.json().remaining, 0)
+
+    // Peek once more: still 0, state was not mutated
+    res = await fastify.inject('/peek')
+    t.assert.deepStrictEqual(res.json().remaining, 0)
+
+    await redis.flushall()
+    await redis.quit()
+  })
+
+  test('With { increment: false } it throws on redis error', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    const redis = await new Redis({ host: REDIS_HOST })
+    await fastify.register(rateLimit, {
+      global: false,
+      max: 2,
+      timeWindow: 1000,
+      redis
+    })
+
+    const checkRateLimit = fastify.createRateLimit()
+    fastify.get('/peek', async (req) => checkRateLimit(req, { increment: false }))
+
+    await redis.flushall()
+    await redis.quit()
+
+    const res = await fastify.inject('/peek')
+    t.assert.deepStrictEqual(res.statusCode, 500)
+    t.assert.deepStrictEqual(
+      res.body,
+      '{"statusCode":500,"error":"Internal Server Error","message":"Connection is closed."}'
+    )
+  })
 })
 
 describe('Route rate limit', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,7 @@ import {
 
 declare module 'fastify' {
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
-    createRateLimit(options?: fastifyRateLimit.CreateRateLimitOptions): (req: FastifyRequest) => Promise<
+    createRateLimit(options?: fastifyRateLimit.CreateRateLimitOptions): (req: FastifyRequest, callOptions?: { increment?: boolean }) => Promise<
       | {
         isAllowed: true
         key: string

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -302,6 +302,9 @@ appWithImplicitHttp.route({
         isBanned: boolean;
       }
     >()
+
+    // The limiter function accepts an optional second argument
+    expect(checkRateLimit).type.toBeCallableWith(req, { increment: false })
   }
 })
 


### PR DESCRIPTION
feat: add increment option to createRateLimit

Allow consumers of fastify.createRateLimit() to check the rate limit status without consuming a request, by passing { increment: false } as an optional second argument to the limiter function.

Closes #420

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
