### PR TITLE
feat: add Valkey support via customCommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { parse, format } = require('@lukeed/ms')
 
 const LocalStore = require('./store/LocalStore')
 const RedisStore = require('./store/RedisStore')
+const ValkeyStore = require('./store/ValkeyStore')
 
 const defaultMax = 1000
 const defaultTimeWindow = 60000
@@ -118,6 +119,8 @@ async function fastifyRateLimit (fastify, settings) {
   } else {
     if (settings.redis) {
       pluginComponent.store = new RedisStore(globalParams.continueExceeding, globalParams.exponentialBackoff, settings.redis, settings.nameSpace)
+    } else if (settings.valkey) {
+      pluginComponent.store = new ValkeyStore(globalParams.continueExceeding, globalParams.exponentialBackoff, settings.valkey, settings.nameSpace)
     } else {
       pluginComponent.store = new LocalStore(globalParams.continueExceeding, globalParams.exponentialBackoff, settings.cache)
     }

--- a/store/ValkeyStore.js
+++ b/store/ValkeyStore.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const lua = `
+  local key = KEYS[1]
+  local timeWindow = tonumber(ARGV[1])
+  local max = tonumber(ARGV[2])
+  local continueExceeding = ARGV[3] == 'true'
+  local exponentialBackoff = ARGV[4] == 'true'
+  local MAX_SAFE_INTEGER = (2^53) - 1
+  local current = redis.call('INCR', key)
+
+  if current == 1 or (continueExceeding and current > max) then
+    redis.call('PEXPIRE', key, timeWindow)
+  elseif exponentialBackoff and current > max then
+    local backoffExponent = current - max - 1
+    timeWindow = math.min(timeWindow * (2 ^ backoffExponent), MAX_SAFE_INTEGER)
+    redis.call('PEXPIRE', key, timeWindow)
+  else
+    timeWindow = redis.call('PTTL', key)
+  end
+
+  return {current, timeWindow}
+`
+
+function ValkeyStore (continueExceeding, exponentialBackoff, valkey, key = 'fastify-rate-limit-') {
+  this.continueExceeding = continueExceeding
+  this.exponentialBackoff = exponentialBackoff
+  this.valkey = valkey
+  this.key = key
+}
+
+ValkeyStore.prototype.incr = function (ip, cb, timeWindow, max) {
+  const args = ['EVAL', lua, '1', this.key + ip,
+    String(timeWindow), String(max),
+    String(this.continueExceeding), String(this.exponentialBackoff)]
+
+  this.valkey.customCommand(args).then(
+    (result) => cb(null, { current: Number(result[0]), ttl: Number(result[1]) }),
+    (err) => cb(err, null)
+  )
+}
+
+ValkeyStore.prototype.child = function (routeOptions) {
+  return new ValkeyStore(
+    routeOptions.continueExceeding,
+    routeOptions.exponentialBackoff,
+    this.valkey,
+    `${this.key}${routeOptions.routeInfo.method}${routeOptions.routeInfo.url}-`
+  )
+}
+
+module.exports = ValkeyStore

--- a/test/valkey-rate-limit.test.js
+++ b/test/valkey-rate-limit.test.js
@@ -1,0 +1,175 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const Fastify = require('fastify')
+const rateLimit = require('../index')
+
+function createMockValkey () {
+  const store = {}
+  return {
+    customCommand (args) {
+      const [cmd, script, numKeys, key, timeWindow, max, continueExceeding, exponentialBackoff] = args
+
+      if (cmd !== 'EVAL') {
+        return Promise.reject(new Error(`Unexpected command: ${cmd}`))
+      }
+
+      const tw = Number(timeWindow)
+      const m = Number(max)
+      const contExc = continueExceeding === 'true'
+      const expBack = exponentialBackoff === 'true'
+
+      if (!store[key]) {
+        store[key] = { current: 0, ttl: tw }
+      }
+      store[key].current++
+      const current = store[key].current
+
+      if (current === 1 || (contExc && current > m)) {
+        store[key].ttl = tw
+      } else if (expBack && current > m) {
+        const backoffExponent = current - m - 1
+        store[key].ttl = Math.min(tw * (2 ** backoffExponent), Number.MAX_SAFE_INTEGER)
+      }
+
+      return Promise.resolve([current, store[key].ttl])
+    }
+  }
+}
+
+function createFailingValkey () {
+  return {
+    customCommand () {
+      return Promise.reject(new Error('Valkey connection error'))
+    }
+  }
+}
+
+describe('Valkey rate limit', () => {
+  test('With valkey store', async (t) => {
+    t.plan(21)
+    const fastify = Fastify()
+    const valkey = createMockValkey()
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      valkey
+    })
+
+    fastify.get('/', async () => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.ok(res)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '1')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(
+      res.headers['content-type'],
+      'application/json; charset=utf-8'
+    )
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+    t.assert.deepStrictEqual(res.headers['retry-after'], '1')
+    t.assert.deepStrictEqual(
+      {
+        statusCode: 429,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded, retry in 1 second'
+      },
+      JSON.parse(res.payload)
+    )
+
+    res = await fastify.inject('/')
+    t.assert.deepStrictEqual(res.statusCode, 429)
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-limit'], '2')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-remaining'], '0')
+    t.assert.deepStrictEqual(res.headers['x-ratelimit-reset'], '1')
+
+    await fastify.close()
+  })
+
+  test('With valkey store - skipOnError', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    const valkey = createFailingValkey()
+    await fastify.register(rateLimit, {
+      max: 2,
+      timeWindow: 1000,
+      valkey,
+      skipOnError: true
+    })
+
+    fastify.get('/', async () => 'hello!')
+
+    const res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'hello!')
+
+    await fastify.close()
+  })
+
+  test('With valkey store - route rate limit', async (t) => {
+    t.plan(4)
+    const fastify = Fastify()
+    const valkey = createMockValkey()
+    await fastify.register(rateLimit, {
+      global: false,
+      valkey
+    })
+
+    fastify.get('/', {
+      config: {
+        rateLimit: {
+          max: 1,
+          timeWindow: 1000
+        }
+      }
+    }, async () => 'hello!')
+
+    let res
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'hello!')
+
+    res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 429)
+    t.assert.ok(res.headers['retry-after'])
+
+    await fastify.close()
+  })
+
+  test('With valkey store - nameSpace', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    const valkey = createMockValkey()
+    await fastify.register(rateLimit, {
+      max: 1,
+      timeWindow: 1000,
+      valkey,
+      nameSpace: 'my-app-'
+    })
+
+    fastify.get('/', async () => 'hello!')
+
+    const res = await fastify.inject('/')
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'hello!')
+
+    await fastify.close()
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -153,6 +153,7 @@ declare namespace fastifyRateLimit {
     global?: boolean;
     cache?: number;
     redis?: any;
+    valkey?: any;
     nameSpace?: string;
     addHeaders?: DefaultAddHeaders | DraftSpecAddHeaders;
     addHeadersOnExceeding?:


### PR DESCRIPTION
## Summary

Adds native Valkey support using `customCommand(['EVAL', ...])` instead of ioredis-specific `defineCommand`. This allows using `@valkey/valkey-glide` or `fastify-valkey-glide` clients directly.

### Changes

- **store/ValkeyStore.js**: New store implementation using `customCommand` for Lua script execution
- **index.js**: Added `valkey` option alongside existing `redis` option
- **types/index.d.ts**: Added `valkey` to `RateLimitPluginOptions`
- **test/valkey-rate-limit.test.js**: 4 tests with mocked Valkey client (rate limiting, skipOnError, route-level, nameSpace)

### Usage

```js
import { GlideClient } from '@valkey/valkey-glide'

const valkey = await GlideClient.createClient({ addresses: [{ host: 'localhost', port: 6379 }] })

fastify.register(rateLimit, {
  max: 100,
  timeWindow: '1 minute',
  valkey
})
```

### Test results

All existing tests pass. 4 new Valkey-specific tests pass with a mock client.

Closes #436